### PR TITLE
item ommision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,37 @@ Outputs this:
       <avatar_url type="str">https://avatars0.githubusercontent.com/u/1?v=4</avatar_url>
     </all>
 
+Omit List item
+--------------
+
+By default, items in an array are wrapped in <item></item>. However, you can change this easily in your code like this:
+
+.. code-block:: python
+
+    from json2xml import json2xml
+    from json2xml.utils import readfromurl, readfromstring, readfromjson
+    data = readfromstring(
+        '{"my_items":[{"my_item":{"id":1} },{"my_item":{"id":2} }]}'
+    )
+    print(json2xml.Json2xml(data, item_wrap=False).to_xml())
+
+
+Outputs this:
+
+.. code-block:: xml
+
+    <?xml version="1.0" ?>
+    <all>
+      <my_items type="list">
+        <my_item>
+            <id type="int">1</id>
+        </my_item>
+        <my_item>
+            <id type="int">2</id>
+        </my_item>
+      </list>
+    </all>
+
 Optional Attribute Type Support
 -------------------------------
 

--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -134,7 +134,7 @@ def default_item_func(parent):
     return "item"
 
 
-def convert(obj, ids, attr_type, item_func, cdata, parent="root"):
+def convert(obj, ids, attr_type, item_func, cdata, item_wrap, parent="root"):
     """Routes the elements of an object to the right function to convert them
     based on their data type"""
 
@@ -157,15 +157,15 @@ def convert(obj, ids, attr_type, item_func, cdata, parent="root"):
         return convert_none(item_name, "", attr_type, cdata)
 
     if isinstance(obj, dict):
-        return convert_dict(obj, ids, parent, attr_type, item_func, cdata)
+        return convert_dict(obj, ids, parent, attr_type, item_func, cdata, item_wrap)
 
     if isinstance(obj, collections.Iterable):
-        return convert_list(obj, ids, parent, attr_type, item_func, cdata)
+        return convert_list(obj, ids, parent, attr_type, item_func, cdata, item_wrap)
 
     raise TypeError("Unsupported data type: %s (%s)" % (obj, type(obj).__name__))
 
 
-def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
+def convert_dict(obj, ids, parent, attr_type, item_func, cdata, item_wrap):
     """Converts a dict into an XML string."""
     LOG.info(
         'Inside convert_dict(): obj type is: "%s", obj="%s"'
@@ -201,7 +201,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
                 % (
                     key,
                     make_attrstring(attr),
-                    convert_dict(val, ids, key, attr_type, item_func, cdata),
+                    convert_dict(val, ids, key, attr_type, item_func, cdata, item_wrap),
                     key,
                 )
             )
@@ -214,7 +214,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
                 % (
                     key,
                     make_attrstring(attr),
-                    convert_list(val, ids, key, attr_type, item_func, cdata),
+                    convert_list(val, ids, key, attr_type, item_func, cdata, item_wrap),
                     key,
                 )
             )
@@ -230,7 +230,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
     return "".join(output)
 
 
-def convert_list(items, ids, parent, attr_type, item_func, cdata):
+def convert_list(items, ids, parent, attr_type, item_func, cdata, item_wrap):
     """Converts a list into an XML string."""
     LOG.info("Inside convert_list()")
     output = []
@@ -258,20 +258,28 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
 
         elif isinstance(item, dict):
             if not attr_type:
-                addline(
-                    "<%s>%s</%s>"
-                    % (
-                        item_name,
-                        convert_dict(item, ids, parent, attr_type, item_func, cdata),
-                        item_name,
+                if (item_wrap):
+                    addline(
+                        "<%s>%s</%s>"
+                        % (
+                            item_name,
+                            convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
+                            item_name,
+                        )
                     )
-                )
+                else:
+                    addline(
+                        "%s"
+                        % (
+                            convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
+                        )
+                    )
             else:
                 addline(
                     '<%s type="dict">%s</%s>'
                     % (
                         item_name,
-                        convert_dict(item, ids, parent, attr_type, item_func, cdata),
+                        convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
                         item_name,
                     )
                 )
@@ -283,7 +291,7 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
                     % (
                         item_name,
                         make_attrstring(attr),
-                        convert_list(item, ids, item_name, attr_type, item_func, cdata),
+                        convert_list(item, ids, item_name, attr_type, item_func, cdata, item_wrap),
                         item_name,
                     )
                 )
@@ -293,7 +301,7 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
                     % (
                         item_name,
                         make_attrstring(attr),
-                        convert_list(item, ids, item_name, attr_type, item_func, cdata),
+                        convert_list(item, ids, item_name, attr_type, item_func, cdata, item_wrap),
                         item_name,
                     )
                 )
@@ -361,6 +369,7 @@ def dicttoxml(
     custom_root="root",
     ids=False,
     attr_type=True,
+    item_wrap=True,
     item_func=default_item_func,
     cdata=False,
 ):
@@ -377,6 +386,8 @@ def dicttoxml(
     - item_func specifies what function should generate the element name for
       items in a list.
       Default is 'item'
+    - item_wrap specifies whether to nest items in array in <item/>
+      Default is True
     - cdata specifies whether string values should be wrapped in CDATA sections.
       Default is False
     """
@@ -387,6 +398,6 @@ def dicttoxml(
     output = []
     output.append('<?xml version="1.0" encoding="UTF-8" ?>')
     output.append(
-        f"<{custom_root}>{convert(obj, ids, attr_type, item_func, cdata, parent=custom_root)}</{custom_root}>"
+        f"<{custom_root}>{convert(obj, ids, attr_type, item_func, cdata, item_wrap, parent=custom_root)}</{custom_root}>"
     )
     return "".join(output).encode("utf-8")

--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -275,14 +275,22 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata, item_wrap):
                         )
                     )
             else:
-                addline(
-                    '<%s type="dict">%s</%s>'
-                    % (
-                        item_name,
-                        convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
-                        item_name,
+                if (item_wrap):
+                    addline(
+                        '<%s type="dict">%s</%s>'
+                        % (
+                            item_name,
+                            convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
+                            item_name,
+                        )
                     )
-                )
+                else:
+                    addline(
+                        '%s'
+                        % (
+                            convert_dict(item, ids, parent, attr_type, item_func, cdata, item_wrap),
+                        )
+                    )
 
         elif isinstance(item, collections.Iterable):
             if not attr_type:

--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Optional, Any
 from xml.dom.minidom import parseString
-from json2xml import dicttoxml
+import dicttoxml
 
 
 class Json2xml:
@@ -10,13 +10,15 @@ class Json2xml:
             wrapper: str = "all",
             root: bool = True,
             pretty: bool = True,
-            attr_type: bool = True
+            attr_type: bool = True,
+            item_wrap: bool = True
     ):
         self.data = data
         self.pretty = pretty
         self.wrapper = wrapper
         self.attr_type = attr_type
         self.root = root
+        self.item_wrap = item_wrap
 
     def to_xml(self) -> Optional[Any]:
         """
@@ -27,7 +29,8 @@ class Json2xml:
                 self.data,
                 root=self.root,
                 custom_root=self.wrapper,
-                attr_type=self.attr_type
+                attr_type=self.attr_type,
+                item_wrap=self.item_wrap
             )
             if self.pretty:
                 return parseString(xml_data).toprettyxml()

--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Optional, Any
 from xml.dom.minidom import parseString
-import dicttoxml
+from json2xml import dicttoxml
 
 
 class Json2xml:

--- a/json2xml/utils.py
+++ b/json2xml/utils.py
@@ -16,7 +16,6 @@ class StringReadError(Exception):
     pass
 
 
-
 def readfromjson(filename: str) -> Dict[str, str]:
     """
     Reads a json string and emits json string

--- a/tests/test_json2xml.py
+++ b/tests/test_json2xml.py
@@ -89,3 +89,24 @@ class TestJson2xml(unittest.TestCase):
         assert "test" in old_dict.keys()
         # reverse test, say a wrapper called ramdom won't be present
         assert "random" not in old_dict.keys()
+
+    def test_item_wrap(self):
+        data = readfromstring(
+            '{"my_items":[{"my_item":{"id":1} },{"my_item":{"id":2} }]}'
+        )
+        xmldata = json2xml.Json2xml(data, root=False, pretty=False).to_xml()
+        old_dict = xmltodict.parse(xmldata)
+        # item must be present within my_items
+        assert "item" in old_dict['all']['my_items']
+
+        xmldata = json2xml.Json2xml(data, root=False, pretty=False, item_wrap=False, attr_type=False).to_xml()
+        old_dict = xmltodict.parse(xmldata)
+        # my_item must be present within my_items
+        assert "my_item" in old_dict['all']['my_items']
+
+        xmldata = json2xml.Json2xml(data, root=False, pretty=False, item_wrap=False).to_xml()
+        print(xmldata)
+        old_dict = xmltodict.parse(xmldata)
+        # my_item must be present within my_items
+        print(old_dict['all']['my_items'])
+        assert "my_item" in old_dict['all']['my_items']


### PR DESCRIPTION
Wrapping array items in `<item>...</item>` should be optional

This PR supports:

```json
{"my_items":[{"my_item":{"id":1} },{"my_item":{"id":2} }]}
```

conversion to:
```xml
    <all>
      <my_items type="list">
        <my_item>
            <id type="int">1</id>
        </my_item>
        <my_item>
            <id type="int">2</id>
        </my_item>
      </list>
    </all>
```
