### PR TITLE
Feat: install pytest separately and run pytests now

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,4 +38,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-        # python setup.py test


### PR DESCRIPTION
Since pytest is removed from the project's direct dependencies, we install it separately in the task runner itself.