### PR TITLE
fix: issue with uncaught UnicodeDecodeError

### DIFF
--- a/json2xml/__init__.py
+++ b/json2xml/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Vinit Kumar"""
 __email__ = "mail@vinitkumar.me"
-__version__ = "3.12.0"
+__version__ = "3.14.0"
 
 
 # from .utils import readfromurl, readfromstring, readfromjson

--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -1,4 +1,3 @@
-import xml
 from typing import Optional, Any
 from defusedxml.minidom import parseString
 from pyexpat import ExpatError

--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -1,6 +1,9 @@
+import xml
 from typing import Optional, Any
 from defusedxml.minidom import parseString
+from pyexpat import ExpatError
 from json2xml import dicttoxml
+from .utils import InvalidDataError
 
 
 class Json2xml:
@@ -33,6 +36,10 @@ class Json2xml:
                 item_wrap=self.item_wrap,
             )
             if self.pretty:
-                return parseString(xml_data).toprettyxml()
+                try:
+                    result = parseString(xml_data).toprettyxml()
+                except ExpatError as e:
+                    raise InvalidDataError
+                return result
             return xml_data
         return None

--- a/json2xml/utils.py
+++ b/json2xml/utils.py
@@ -7,6 +7,8 @@ import requests
 class JSONReadError(Exception):
     pass
 
+class InvalidDataError(Exception):
+    pass
 
 class URLReadError(Exception):
     pass

--- a/tests/test_json2xml.py
+++ b/tests/test_json2xml.py
@@ -13,7 +13,7 @@ import json
 
 from json2xml import json2xml
 from json2xml.dicttoxml import dicttoxml
-from json2xml.utils import readfromjson, readfromstring, readfromurl, JSONReadError, StringReadError, URLReadError
+from json2xml.utils import InvalidDataError, readfromjson, readfromstring, readfromurl, JSONReadError, StringReadError, URLReadError
 
 
 class TestJson2xml(unittest.TestCase):
@@ -163,3 +163,9 @@ class TestJson2xml(unittest.TestCase):
         payload = {'mock': 'payload'}
         result = dicttoxml(payload, attr_type=False, custom_root="element")
         assert b'<?xml version="1.0" encoding="UTF-8" ?><element><mock>payload</mock></element>' == result
+
+    def test_bad_data(self):
+        data = b"!\0a\8f".decode("utf-8")
+        with pytest.raises(InvalidDataError) as pytest_wrapped_e:
+            result = json2xml.Json2xml(data).to_xml()
+        assert pytest_wrapped_e.type == InvalidDataError


### PR DESCRIPTION
Even though, there are methods to safely get the json from file, string,
or url even, there is no surely that people will not pass their own data
into the json2xml.Json2xml() contructor.

However, if the data is corrupt or mal-formed, there is a chance an
exception can be raised, brining the program to a halt.

Hence, a new error type is introduced, that protects against it and
raises InvalidDataError exception which can that be caught and logged in
a program that uses Json2xml.

- Github Issue: #106

Authored-by: Vinit Kumar <mail@vinitkumar.me>
Signed-off-by: Vinit Kumar <mail@vinitkumar.me>