### PR TITLE
refactor: xmltodict is only test dependency

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,16 +30,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r requirements.txt
-        python setup.py install
-    - name: Lint with flake8
-      run: |
         pip install flake8
         pip install xmltodict==0.12.0
         pip install pytest==7.0.1
         pip install coverage==6.3.2
         pip install py==1.11.0
+        python setup.py install
+    - name: Lint with flake8
+      run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 json2xml/ --exit-zero
+        flake8 json2xml/
     - name: Unit tests
       run: |
         coverage run -m pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,16 +30,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r requirements.txt
-        pip install flake8
         pip install xmltodict==0.12.0
         pip install pytest==7.0.1
         pip install coverage==6.3.2
         pip install py==1.11.0
         python setup.py install
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 json2xml/
     - name: Unit tests
       run: |
         coverage run -m pytest

--- a/README.rst
+++ b/README.rst
@@ -197,9 +197,10 @@ This is provided by pytest, which is straight forward.
 
  .. code-block:: bash
 
-    python3.8 -mvenv venv
-    source venv/bin/activate
-    python setup.py test
+    virtualenv venv -p $(which python3.9)
+    pip install -r requirements-dev.txt
+    python setup.py install
+    pytest
 
 
 Credits

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+xmltodict==0.12.0
+pytest==7.0.1
+coverage==6.3.2
+py==1.11.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
 requests>=2.20.0
 defusedxml==0.7.1
-xmltodict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,3 @@ requests==2.26.0
     # via -r requirements.in
 urllib3==1.26.7
     # via requests
-xmltodict==0.12.0
-    # via -r requirements.in


### PR DESCRIPTION
- Cleanup Readme
- Remove xmltodict as a dep from codebase, we only need it as a test dependency.
- Make the list of contributors correct.