### PR TITLE
add python3.11 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, pypy-3.7, pypy-3.8, pypy-3.9, 3.10.2, '3.11.0-alpha.6']
+        python-version: [3.7, 3.8, 3.9, pypy-3.7, pypy-3.8, pypy-3.9, 3.10.2, '3.11.0-beta.1']
         os: [
           ubuntu-20.04,
           windows-2022,

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, pypy-3.7, pypy-3.8, pypy-3.9, 3.10.2, '3.11.0-beta.1']
+        python-version: [3.7, 3.8, 3.9, pypy-3.9, pypy-3.8, pypy-3.9, 3.10.2, '3.11.0-beta.1']
         os: [
           ubuntu-20.04,
           windows-2022,


### PR DESCRIPTION
Add support for Python 3.11.0-beta.1 and PyPy 3.9 in the CI matrix. Deprecate the PyPy 3.7