### PR TITLE
fix: use SystemRandom as a secure way for generating Random Integers

### DIFF
--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -16,8 +16,10 @@ import logging
 import numbers
 import os
 from collections.abc import Callable, Sequence
-from random import randint
+from random import SystemRandom
 from typing import Any, Dict, Union
+
+safe_random = SystemRandom()
 
 from defusedxml.minidom import parseString
 
@@ -27,7 +29,7 @@ LOG = logging.getLogger("dicttoxml")  # pragma: no cover
 
 def make_id(element: str, start: int = 100000, end: int = 999999) -> str:
     """Returns a random integer"""
-    return f"{element}_{randint(start, end)}"
+    return f"{element}_{safe_random.randint(start, end)}"
 
 
 def get_unique_id(element: str) -> str:

--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -18,11 +18,9 @@ import os
 from collections.abc import Callable, Sequence
 from random import SystemRandom
 from typing import Any, Dict, Union
-
-safe_random = SystemRandom()
-
 from defusedxml.minidom import parseString
 
+safe_random = SystemRandom()
 DEBUGMODE = os.getenv("DEBUGMODE", False)  # pragma: no cover
 LOG = logging.getLogger("dicttoxml")  # pragma: no cover
 

--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -18,6 +18,7 @@ import os
 from collections.abc import Callable, Sequence
 from random import SystemRandom
 from typing import Any, Dict, Union
+
 from defusedxml.minidom import parseString
 
 safe_random = SystemRandom()


### PR DESCRIPTION
fixes #155 