### PR TITLE
Use fixture for attrs with dict and remove comment

### DIFF
--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -261,7 +261,6 @@ def dict2xml_str(
         if len(val_attr) > 0 and not item_wrap:
             attrstring = make_attrstring(val_attr)
             return f"<{parent}{attrstring}>{subtree}</{parent}>"
-        # should not return if there is an attr present
         return f"<{parent}>{subtree}</{parent}>"
     elif item.get("@flat", False) or (parentIsList and not item_wrap):
         return subtree

--- a/tests/test_dict2xml.py
+++ b/tests/test_dict2xml.py
@@ -1,6 +1,7 @@
 from json2xml import dicttoxml
 import pytest
 
+
 class TestDict2xml:
     def test_dict2xml_with_namespaces(self):
         data = {'ns1:node1': 'data in namespace 1', 'ns2:node2': 'data in namespace 2'}

--- a/tests/test_dict2xml.py
+++ b/tests/test_dict2xml.py
@@ -1,5 +1,5 @@
 from json2xml import dicttoxml
-
+import pytest
 
 class TestDict2xml:
     def test_dict2xml_with_namespaces(self):
@@ -111,11 +111,9 @@ class TestDict2xml:
         assert '<Bicycles xml:lang="nl">Wheels &amp; Steers</Bicycles>' == dicttoxml.dicttoxml(
             dict_with_attrs, root=root, attr_type=False).decode('UTF-8')
 
-    def test_dict2xml_list_items_with_attrs(self):
-        '''
-        Currently has an item wrap because item_name = 'item' this should not be the case with item_wrap as False
-        '''
-        dict_with_attrs = {
+    @pytest.fixture
+    def dict_with_attrs(self) -> dict:
+        return {
             'transportation-mode': [
                     {
                         '@attrs': {'xml:lang': 'nl'},
@@ -131,6 +129,11 @@ class TestDict2xml:
                     }
             ]
         }
+
+    def test_dict2xml_list_items_with_attrs(self, dict_with_attrs):
+        '''With list headers = True
+        '''
+
         wanted_xml_result = b'<transportation-mode xml:lang="nl">Fiets</transportation-mode>' \
             b'<transportation-mode xml:lang="nl">Bus</transportation-mode>' \
             b'<transportation-mode xml:lang="en">Bike</transportation-mode>'


### PR DESCRIPTION
Thanks for accepting my previous PR. I wanted to do some refactoring to keep the code clean and readable. So I have added a fixture to reuse the "dict_with_attr" in another test. But before adding another test I would like to agree on the expected result.

Current test is
```Python
    @pytest.fixture
    def dict_with_attrs(self) -> dict:
        return {
            'transportation-mode': [
                    {
                        '@attrs': {'xml:lang': 'nl'},
                        '@val': 'Fiets'
                    },
                    {
                        '@attrs': {'xml:lang': 'nl'},
                        '@val': 'Bus'
                    },
                    {
                        '@attrs': {'xml:lang': 'en'},
                        '@val': 'Bike'
                    }
            ]
        }

    def test_dict2xml_list_items_with_attrs(self, dict_with_attrs):
        '''With list headers = True
        '''

        wanted_xml_result = b'<transportation-mode xml:lang="nl">Fiets</transportation-mode>' \
            b'<transportation-mode xml:lang="nl">Bus</transportation-mode>' \
            b'<transportation-mode xml:lang="en">Bike</transportation-mode>'
        xml_result = dicttoxml.dicttoxml(
            dict_with_attrs,
            root=False,
            attr_type=False,
            item_wrap=False,
            list_headers=True)

        assert xml_result == wanted_xml_result
```
But I would like to add a test where list_headers=False
```Python
def test_dict2xml_list_items_with_attrs_no_header(self, dict_with_attrs):
        '''With list headers = True
        '''

        wanted_xml_result = 🤷
        xml_result = dicttoxml.dicttoxml(
            dict_with_attrs,
            root=False,
            attr_type=False,
            item_wrap=False,
            list_headers=False)

        assert xml_result == wanted_xml_result
```

Current result is 
```Python
b'<transportation-mode>FietsBusBike</transportation-mode>'
```
Which seams not correct. I would expect an error that it is not possible or the following result:
```Python
b'<transportation-mode xml:lang: "nl">Fiets</transportation-mode>'\
b'<transportation-mode xml:lang: "nl">Bus</transportation-mode>'\
b'<transportation-mode xml:lang: "en">Bike</transportation-mode>'
```
Let me know what you think and I'll add it to this PR. 