### PR TITLE
fix missing encoding indication in pretty mode

### DIFF
--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -42,7 +42,7 @@ class Json2xml:
             )
             if self.pretty:
                 try:
-                    result = parseString(xml_data).toprettyxml()
+                    result = parseString(xml_data).toprettyxml(encoding="UTF-8").decode()
                 except ExpatError:
                     raise InvalidDataError
                 return result


### PR DESCRIPTION
When using `pretty=True`, the `encoding="UTF-8"` indication is missing:

```python
Json2xml({"data": [123]}, pretty=True).to_xml()
'<?xml version="1.0" ?>\n<all>\n\t<data type="list">\n\t\t<item type="int">123</item>\n\t</data>\n</all>\n'
```

However, it is present when `pretty=False`: 

```python
Json2xml({"data": [123]}, pretty=False).to_xml()
b'<?xml version="1.0" encoding="UTF-8" ?><all><data type="list"><item type="int">123</item></data></all>'
```

Since in `pretty=True` mode, the encoding remains `UTF-8`, the contents should still indicate it.
The proposed fix produces the following:

```python
Json2xml({"data": [123]}, pretty=True).to_xml() 
'<?xml version="1.0" encoding="UTF-8"?>\n<all>\n\t<data type="list">\n\t\t<item type="int">123</item>\n\t</data>\n</all>\n'
```

Diff emphasis before/after with rendered whitespaces:
```diff
- <?xml version="1.0" ?>
+ <?xml version="1.0" encoding="UTF-8"?>
<all>
	<data type="list">
		<item type="int">123</item>
	</data>
</all>
```

