### PR TITLE
Feat/latest python 3.14 alpha7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,15 +26,15 @@ jobs:
         ]
         include:
           # Add exact version 3.14.0-alpha.0 for ubuntu-latest only
-          - python-version: 3.14.0-alpha.6
+          - python-version: 3.14.0-alpha.7
             tox-python-version: py314-full
             os: ubuntu-latest
         exclude:
           # Exclude other OSes with Python 3.14.0-alpha.0
-          - python-version: 3.14.0-alpha.6
+          - python-version: 3.14.0-alpha.7
             tox-python-version: py314-full
             os: windows-latest
-          - python-version: 3.14.0-alpha.6
+          - python-version: 3.14.0-alpha.7
             os: macos-latest
             tox-python-version: py314-full
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy-3.10, pypy-3.11, '3.10', '3.11', '3.12', '3.13']
-        tox-python-version: [pypy3.10, pypy3.11, py310, py311, py312, py313]
+        python-version: [pypy-3.10, pypy-3.11, '3.10', '3.11', '3.12', '3.13', '3.13t']
+        tox-python-version: [pypy3.10, pypy3.11, py310, py311, py312, py313, py313t]
         os: [
           ubuntu-latest,
           windows-latest,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, py312, py313, pypy310, pypy311, py314-full
+envlist = py310, py311, py312, py313, py313t, pypy310, pypy311, py314-full
 
 [testenv]
 deps =
@@ -10,3 +10,9 @@ allowlist_externals = pytest
 
 commands =
     pytest --cov --cov-report=xml
+
+[testenv:py313t]
+description = Python 3.13 free threaded environment
+basepython = python3.13t
+deps = {[testenv]deps}
+commands = {[testenv]commands}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update test matrix to include additional Python versions: 3.13t and 3.14.0-alpha.7 for continuous integration testing