### PR TITLE
check arm build ubuntu

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,6 +33,7 @@ jobs:
           ubuntu-latest,
           windows-latest,
           macos-latest,
+          "ubuntu-24.04-arm"
         ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include ubuntu-24.04-arm in the test matrix for Python package workflow