### PR TITLE
feat: add CLI support for json2xml-py

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,127 @@
+# json2xml Benchmark Results
+
+Comprehensive performance comparison between Python implementations and the Go version of json2xml.
+
+## Test Environment
+
+- **Machine**: Apple Silicon (aarch64)
+- **OS**: macOS
+- **Date**: January 14, 2026
+
+### Implementations Tested
+
+| Implementation | Version | Notes |
+|----------------|---------|-------|
+| CPython | 3.14.2 | Homebrew installation |
+| CPython | 3.15.0a4 | Latest alpha via uv |
+| PyPy | 3.10.16 | JIT-compiled Python |
+| Go | 1.0.0 | json2xml-go |
+
+## Test Data
+
+| Size | Description | Bytes |
+|------|-------------|-------|
+| Small | Simple object `{"name": "John", "age": 30, "city": "New York"}` | 47 |
+| Medium | `bigexample.json` (patent data) | 2,598 |
+| Large | 1,000 generated records with nested structures | 323,130 |
+| Very Large | 5,000 generated records with nested structures | 1,619,991 |
+
+## Results
+
+### Individual Test Results
+
+| Test | CPython 3.14.2 | CPython 3.15.0a4 | PyPy 3.10.16 | Go |
+|------|----------------|------------------|--------------|-----|
+| **Small JSON** (47 bytes) | 75.46ms | 55.74ms (**1.4x faster**) | 121.47ms (1.6x slower) | 3.69ms (**20.4x faster**) |
+| **Medium JSON** (2.6KB) | 73.87ms | 57.98ms (**1.3x faster**) | 125.73ms (1.7x slower) | 4.32ms (**17.1x faster**) |
+| **Large JSON** (323KB) | 419.67ms | 328.98ms (**1.3x faster**) | 517.51ms (1.2x slower) | 67.13ms (**6.3x faster**) |
+| **Very Large JSON** (1.6MB) | 2.09s | 1.86s (**1.1x faster**) | 1.42s (**1.5x faster**) | 287.58ms (**7.3x faster**) |
+
+### Summary (Average Across All Tests)
+
+| Implementation | Avg Time | vs CPython 3.14.2 |
+|----------------|----------|-------------------|
+| **Go** | 90.68ms | **7.34x faster** 🚀 |
+| **PyPy 3.10.16** | 545.58ms | **1.22x faster** |
+| **CPython 3.15.0a4** | 575.45ms | **1.16x faster** |
+| **CPython 3.14.2** | 665.23ms | baseline |
+
+## Key Observations
+
+### 1. Go is the Clear Winner
+
+Go outperforms all Python implementations by a significant margin:
+- **7.34x faster** than CPython 3.14.2 on average
+- Up to **20x faster** for small inputs due to minimal startup overhead
+- Consistent performance across all input sizes
+
+### 2. CPython 3.15.0a4 Shows Promising Improvements
+
+The latest Python alpha demonstrates consistent performance gains:
+- **13-35% faster** than CPython 3.14.2 across all test sizes
+- Improvements likely due to ongoing interpreter optimizations
+
+### 3. PyPy Has Interesting Trade-offs
+
+PyPy's JIT compiler creates a unique performance profile:
+- **Slower for small/medium inputs**: JIT compilation overhead hurts for quick operations
+- **Faster for very large inputs**: JIT shines on the 5K record test (1.5x faster than CPython)
+- Best suited for long-running processes or batch processing
+
+### 4. Startup Overhead Dominates Small Inputs
+
+Python's interpreter startup time is significant:
+- CPython takes **55-75ms** even for 47 bytes of JSON
+- Go takes only **3.7ms** for the same operation
+- For CLI tools processing small files, Go provides a much better user experience
+
+## When to Use Each Implementation
+
+| Use Case | Recommended |
+|----------|-------------|
+| CLI tool for small/medium files | **Go** (json2xml-go) |
+| High-throughput batch processing | **Go** or **PyPy** |
+| Integration with Python codebase | **CPython 3.15+** |
+| One-off conversions in scripts | **CPython** (any version) |
+
+## Running the Benchmarks
+
+### Python Multi-Implementation Benchmark
+
+```bash
+# Set the Go CLI path
+export JSON2XML_GO_CLI=/path/to/json2xml-go
+
+# Run the benchmark
+python benchmark_multi_python.py
+```
+
+### Simple Python vs Go Benchmark
+
+```bash
+# Set paths via environment variables (optional)
+export JSON2XML_GO_CLI=/path/to/json2xml-go
+export JSON2XML_EXAMPLES_DIR=/path/to/examples
+
+# Run the benchmark
+python benchmark.py
+```
+
+## Reproducing Results
+
+1. Install required Python versions using `uv`:
+   ```bash
+   uv python install 3.14 3.15.0a4 pypy@3.10
+   ```
+
+2. Build the Go binary:
+   ```bash
+   cd /path/to/json2xml-go
+   go build -o json2xml-go ./cmd/json2xml-go
+   ```
+
+3. Run the multi-Python benchmark:
+   ```bash
+   cd /path/to/json2xml
+   python benchmark_multi_python.py
+   ```

--- a/benchmark.py
+++ b/benchmark.py
@@ -4,6 +4,10 @@ Benchmark script for json2xml-py vs json2xml-go.
 
 Compares performance of Python and Go implementations across
 different JSON sizes.
+
+Environment variables:
+    JSON2XML_GO_CLI: Path to the json2xml-go binary (default: json2xml-go in PATH)
+    JSON2XML_EXAMPLES_DIR: Path to examples directory (default: ./examples relative to script)
 """
 from __future__ import annotations
 
@@ -17,10 +21,13 @@ import tempfile
 import time
 from pathlib import Path
 
-# Paths
+# Base directory for repo-relative defaults
+BASE_DIR = Path(__file__).resolve().parent
+
+# Paths - configurable via environment variables
 PYTHON_CLI = [sys.executable, "-m", "json2xml.cli"]
-GO_CLI = Path("/Users/vinitkumar/projects/go/json2xml-go/json2xml-go")
-EXAMPLES_DIR = Path("/Users/vinitkumar/projects/python/json2xml/examples")
+GO_CLI = Path(os.environ.get("JSON2XML_GO_CLI", "json2xml-go"))
+EXAMPLES_DIR = Path(os.environ.get("JSON2XML_EXAMPLES_DIR", str(BASE_DIR / "examples")))
 
 # Colors for terminal output
 class Colors:

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Benchmark script for json2xml-py vs json2xml-go.
+
+Compares performance of Python and Go implementations across
+different JSON sizes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import string
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Paths
+PYTHON_CLI = [sys.executable, "-m", "json2xml.cli"]
+GO_CLI = Path("/Users/vinitkumar/projects/go/json2xml-go/json2xml-go")
+EXAMPLES_DIR = Path("/Users/vinitkumar/projects/python/json2xml/examples")
+
+# Colors for terminal output
+class Colors:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    BLUE = "\033[0;34m"
+    YELLOW = "\033[1;33m"
+    CYAN = "\033[0;36m"
+    BOLD = "\033[1m"
+    NC = "\033[0m"  # No Color
+
+
+def colorize(text: str, color: str) -> str:
+    """Wrap text in color codes."""
+    return f"{color}{text}{Colors.NC}"
+
+
+def random_string(length: int = 10) -> str:
+    """Generate a random string."""
+    return "".join(random.choices(string.ascii_letters, k=length))
+
+
+def generate_large_json(num_records: int = 1000) -> str:
+    """Generate a large JSON file for benchmarking."""
+    data = []
+    for i in range(num_records):
+        item = {
+            "id": i,
+            "name": random_string(20),
+            "email": f"{random_string(8)}@example.com",
+            "active": random.choice([True, False]),
+            "score": round(random.uniform(0, 100), 2),
+            "tags": [random_string(5) for _ in range(5)],
+            "metadata": {
+                "created": "2024-01-15T10:30:00Z",
+                "updated": "2024-01-15T12:45:00Z",
+                "version": random.randint(1, 100),
+                "nested": {
+                    "level1": {
+                        "level2": {"value": random_string(10)}
+                    }
+                },
+            },
+        }
+        data.append(item)
+    return json.dumps(data)
+
+
+def run_benchmark(
+    cmd: list[str],
+    iterations: int = 10,
+    warmup: int = 2
+) -> dict[str, float]:
+    """
+    Run a benchmark for the given command.
+
+    Returns dict with avg, min, max times in milliseconds.
+
+    Note: cmd is always a list constructed internally by this script,
+    not from external/user input. The subprocess calls are safe.
+    """
+    times = []
+
+    # Warmup runs
+    # Security: cmd is a list constructed internally, not from user input
+    for _ in range(warmup):
+        subprocess.run(cmd, capture_output=True, check=False)  # noqa: S603
+
+    # Timed runs
+    for _ in range(iterations):
+        start = time.perf_counter()
+        result = subprocess.run(cmd, capture_output=True, check=False)  # noqa: S603
+        end = time.perf_counter()
+
+        if result.returncode != 0:
+            print(f"Error: {result.stderr.decode()}")
+            continue
+
+        duration_ms = (end - start) * 1000
+        times.append(duration_ms)
+
+    if not times:
+        return {"avg": 0, "min": 0, "max": 0}
+
+    return {
+        "avg": sum(times) / len(times),
+        "min": min(times),
+        "max": max(times),
+    }
+
+
+def format_time(ms: float) -> str:
+    """Format time in milliseconds."""
+    if ms < 1:
+        return f"{ms * 1000:.2f}µs"
+    elif ms < 1000:
+        return f"{ms:.2f}ms"
+    else:
+        return f"{ms / 1000:.2f}s"
+
+
+def print_header(title: str) -> None:
+    """Print a section header."""
+    print(colorize("=" * 50, Colors.BLUE))
+    print(colorize(f"  {title}", Colors.BOLD))
+    print(colorize("=" * 50, Colors.BLUE))
+
+
+def print_result(name: str, result: dict[str, float]) -> None:
+    """Print benchmark result."""
+    print(f"  {name}:")
+    print(f"    Avg: {format_time(result['avg'])} | "
+          f"Min: {format_time(result['min'])} | "
+          f"Max: {format_time(result['max'])}")
+
+
+def main() -> int:
+    """Run the benchmark suite."""
+    print_header("json2xml Benchmark: Python vs Go")
+    print()
+
+    # Check prerequisites
+    print(colorize("Checking prerequisites...", Colors.YELLOW))
+
+    if not GO_CLI.exists():
+        print(colorize(f"Error: Go binary not found at {GO_CLI}", Colors.RED))
+        print("Please build it first: cd json2xml-go && go build -o json2xml-go ./cmd/json2xml-go")
+        return 1
+
+    print(colorize("✓ Prerequisites met", Colors.GREEN))
+    print()
+
+    # Test configurations
+    iterations = 10
+    results = {}
+
+    # Create temp files for testing
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Small JSON - inline string
+        small_json = '{"name": "John", "age": 30, "city": "New York"}'
+
+        # Medium JSON - existing file
+        medium_json_file = EXAMPLES_DIR / "bigexample.json"
+
+        # Large JSON - generated
+        large_json = generate_large_json(1000)
+        large_json_file = Path(tmpdir) / "large.json"
+        large_json_file.write_text(large_json)
+
+        # Very large JSON
+        very_large_json = generate_large_json(5000)
+        very_large_json_file = Path(tmpdir) / "very_large.json"
+        very_large_json_file.write_text(very_large_json)
+
+        print(colorize("Test file sizes:", Colors.CYAN))
+        print(f"  Small:      {len(small_json)} bytes (inline)")
+        print(f"  Medium:     {medium_json_file.stat().st_size:,} bytes")
+        print(f"  Large:      {large_json_file.stat().st_size:,} bytes (1000 records)")
+        print(f"  Very Large: {very_large_json_file.stat().st_size:,} bytes (5000 records)")
+        print()
+
+        # Benchmark: Small JSON (inline string)
+        print(colorize("--- Small JSON (inline string) ---", Colors.BLUE))
+        py_small = run_benchmark(PYTHON_CLI + ["-s", small_json], iterations)
+        go_small = run_benchmark([str(GO_CLI), "-s", small_json], iterations)
+        print_result("Python", py_small)
+        print_result("Go", go_small)
+        results["small"] = {"python": py_small, "go": go_small}
+        print()
+
+        # Benchmark: Medium JSON (file)
+        print(colorize("--- Medium JSON (bigexample.json) ---", Colors.BLUE))
+        py_medium = run_benchmark(PYTHON_CLI + [str(medium_json_file)], iterations)
+        go_medium = run_benchmark([str(GO_CLI), str(medium_json_file)], iterations)
+        print_result("Python", py_medium)
+        print_result("Go", go_medium)
+        results["medium"] = {"python": py_medium, "go": go_medium}
+        print()
+
+        # Benchmark: Large JSON (file)
+        print(colorize("--- Large JSON (1000 records) ---", Colors.BLUE))
+        py_large = run_benchmark(PYTHON_CLI + [str(large_json_file)], iterations)
+        go_large = run_benchmark([str(GO_CLI), str(large_json_file)], iterations)
+        print_result("Python", py_large)
+        print_result("Go", go_large)
+        results["large"] = {"python": py_large, "go": go_large}
+        print()
+
+        # Benchmark: Very Large JSON (file)
+        print(colorize("--- Very Large JSON (5000 records) ---", Colors.BLUE))
+        py_vlarge = run_benchmark(PYTHON_CLI + [str(very_large_json_file)], iterations)
+        go_vlarge = run_benchmark([str(GO_CLI), str(very_large_json_file)], iterations)
+        print_result("Python", py_vlarge)
+        print_result("Go", go_vlarge)
+        results["very_large"] = {"python": py_vlarge, "go": go_vlarge}
+        print()
+
+    # Summary
+    print_header("SUMMARY")
+    print()
+
+    for size, data in results.items():
+        py_avg = data["python"]["avg"]
+        go_avg = data["go"]["avg"]
+
+        if go_avg > 0:
+            speedup = py_avg / go_avg
+            speedup_str = colorize(f"{speedup:.1f}x faster", Colors.GREEN)
+        else:
+            speedup_str = "N/A"
+
+        print(colorize(f"{size.replace('_', ' ').title()} JSON:", Colors.BOLD))
+        print(f"  Python: {format_time(py_avg)}")
+        print(f"  Go:     {format_time(go_avg)}")
+        print(f"  Go is {speedup_str}")
+        print()
+
+    # Overall average speedup
+    total_py = sum(r["python"]["avg"] for r in results.values())
+    total_go = sum(r["go"]["avg"] for r in results.values())
+    if total_go > 0:
+        overall_speedup = total_py / total_go
+        print(colorize(f"Overall: Go is {overall_speedup:.1f}x faster than Python", Colors.GREEN + Colors.BOLD))
+
+    print()
+    print(colorize("=" * 50, Colors.BLUE))
+    print(colorize("Benchmark complete!", Colors.GREEN))
+    print(colorize("=" * 50, Colors.BLUE))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,8 +3,15 @@
 # Benchmark script for json2xml-py vs json2xml-go
 # Compares performance of Python and Go implementations
 #
+# Environment variables:
+#   GO_CLI: Path to json2xml-go binary (default: json2xml-go in PATH)
+#   MEDIUM_JSON_FILE: Path to medium JSON test file (default: ./examples/bigexample.json)
+#
 
 set -e
+
+# Resolve repository-relative paths based on this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Colors for output
 RED='\033[0;31m'
@@ -18,12 +25,13 @@ echo -e "${BLUE}  json2xml Benchmark: Python vs Go${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo ""
 
-# Configuration
-PYTHON_CLI="python -m json2xml.cli"
-GO_CLI="/Users/vinitkumar/projects/go/json2xml-go/json2xml-go"
+# Configuration - can be overridden via environment variables
+PYTHON_CLI="${PYTHON_CLI:-python -m json2xml.cli}"
+GO_CLI="${GO_CLI:-json2xml-go}"
 ITERATIONS=10
 SMALL_JSON='{"name": "John", "age": 30, "city": "New York"}'
-MEDIUM_JSON="$(cat /Users/vinitkumar/projects/python/json2xml/examples/bigexample.json)"
+MEDIUM_JSON_FILE="${MEDIUM_JSON_FILE:-$SCRIPT_DIR/examples/bigexample.json}"
+MEDIUM_JSON="$(cat "$MEDIUM_JSON_FILE")"
 LARGE_JSON_FILE="/tmp/json2xml_benchmark_large.json"
 
 # Generate a large JSON file for testing

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#
+# Benchmark script for json2xml-py vs json2xml-go
+# Compares performance of Python and Go implementations
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}  json2xml Benchmark: Python vs Go${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Configuration
+PYTHON_CLI="python -m json2xml.cli"
+GO_CLI="/Users/vinitkumar/projects/go/json2xml-go/json2xml-go"
+ITERATIONS=10
+SMALL_JSON='{"name": "John", "age": 30, "city": "New York"}'
+MEDIUM_JSON="$(cat /Users/vinitkumar/projects/python/json2xml/examples/bigexample.json)"
+LARGE_JSON_FILE="/tmp/json2xml_benchmark_large.json"
+
+# Generate a large JSON file for testing
+generate_large_json() {
+    echo -e "${YELLOW}Generating large JSON test file...${NC}"
+    python3 << 'EOF'
+import json
+import random
+import string
+
+def random_string(length=10):
+    return ''.join(random.choices(string.ascii_letters, k=length))
+
+data = []
+for i in range(1000):
+    item = {
+        "id": i,
+        "name": random_string(20),
+        "email": f"{random_string(8)}@example.com",
+        "active": random.choice([True, False]),
+        "score": random.uniform(0, 100),
+        "tags": [random_string(5) for _ in range(5)],
+        "metadata": {
+            "created": "2024-01-15T10:30:00Z",
+            "updated": "2024-01-15T12:45:00Z",
+            "version": random.randint(1, 100),
+            "nested": {
+                "level1": {
+                    "level2": {
+                        "value": random_string(10)
+                    }
+                }
+            }
+        }
+    }
+    data.append(item)
+
+with open("/tmp/json2xml_benchmark_large.json", "w") as f:
+    json.dump(data, f)
+
+print(f"Generated large JSON with 1000 records")
+EOF
+}
+
+# Benchmark function
+benchmark() {
+    local name="$1"
+    local cmd="$2"
+    local iterations="$3"
+    
+    echo -e "${YELLOW}Running: $name${NC}"
+    
+    # Warmup run
+    eval "$cmd" > /dev/null 2>&1
+    
+    # Timed runs
+    local total_time=0
+    local times=()
+    
+    for ((i=1; i<=$iterations; i++)); do
+        local start=$(python3 -c "import time; print(time.perf_counter())")
+        eval "$cmd" > /dev/null 2>&1
+        local end=$(python3 -c "import time; print(time.perf_counter())")
+        local duration=$(python3 -c "print(round(($end - $start) * 1000, 2))")
+        times+=($duration)
+        total_time=$(python3 -c "print($total_time + $duration)")
+    done
+    
+    # Calculate stats
+    local avg=$(python3 -c "print(round($total_time / $iterations, 2))")
+    local min=$(python3 -c "print(min([${times[*]}]))")
+    local max=$(python3 -c "print(max([${times[*]}]))")
+    
+    echo "  Iterations: $iterations"
+    echo "  Avg: ${avg}ms | Min: ${min}ms | Max: ${max}ms"
+    echo ""
+    
+    # Return average time for comparison
+    echo "$avg"
+}
+
+# Check prerequisites
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v python3 &> /dev/null; then
+    echo -e "${RED}Error: python3 not found${NC}"
+    exit 1
+fi
+
+if [ ! -f "$GO_CLI" ]; then
+    echo -e "${YELLOW}Building Go binary...${NC}"
+    cd /Users/vinitkumar/projects/go/json2xml-go
+    go build -o json2xml-go ./cmd/json2xml-go
+fi
+
+echo -e "${GREEN}✓ Prerequisites met${NC}"
+echo ""
+
+# Generate large test file
+generate_large_json
+echo ""
+
+# Small JSON benchmark
+echo -e "${BLUE}--- Small JSON (simple object) ---${NC}"
+py_small=$(benchmark "Python (small)" "$PYTHON_CLI -s '$SMALL_JSON'" $ITERATIONS 2>&1 | tail -1)
+go_small=$(benchmark "Go (small)" "$GO_CLI -s '$SMALL_JSON'" $ITERATIONS 2>&1 | tail -1)
+
+# Medium JSON benchmark (using bigexample.json)
+echo -e "${BLUE}--- Medium JSON (bigexample.json ~3KB) ---${NC}"
+py_medium=$(benchmark "Python (medium)" "$PYTHON_CLI /Users/vinitkumar/projects/python/json2xml/examples/bigexample.json" $ITERATIONS 2>&1 | tail -1)
+go_medium=$(benchmark "Go (medium)" "$GO_CLI /Users/vinitkumar/projects/go/json2xml-go/testdata/bigexample.json" $ITERATIONS 2>&1 | tail -1)
+
+# Large JSON benchmark
+echo -e "${BLUE}--- Large JSON (1000 records, ~250KB) ---${NC}"
+py_large=$(benchmark "Python (large)" "$PYTHON_CLI $LARGE_JSON_FILE" $ITERATIONS 2>&1 | tail -1)
+go_large=$(benchmark "Go (large)" "$GO_CLI $LARGE_JSON_FILE" $ITERATIONS 2>&1 | tail -1)
+
+# Summary
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}              SUMMARY${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+calculate_speedup() {
+    python3 -c "
+py = $1
+go = $2
+if go > 0:
+    speedup = py / go
+    print(f'{speedup:.1f}x faster')
+else:
+    print('N/A')
+"
+}
+
+echo -e "${GREEN}Small JSON:${NC}"
+echo "  Python: ${py_small}ms"
+echo "  Go:     ${go_small}ms"
+echo -e "  Go is $(calculate_speedup $py_small $go_small)"
+echo ""
+
+echo -e "${GREEN}Medium JSON:${NC}"
+echo "  Python: ${py_medium}ms"
+echo "  Go:     ${go_medium}ms"
+echo -e "  Go is $(calculate_speedup $py_medium $go_medium)"
+echo ""
+
+echo -e "${GREEN}Large JSON:${NC}"
+echo "  Python: ${py_large}ms"
+echo "  Go:     ${go_large}ms"
+echo -e "  Go is $(calculate_speedup $py_large $go_large)"
+echo ""
+
+# Cleanup
+rm -f $LARGE_JSON_FILE
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Benchmark complete!${NC}"
+echo -e "${BLUE}========================================${NC}"

--- a/benchmark_multi_python.py
+++ b/benchmark_multi_python.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Multi-Python Benchmark: Compare json2xml performance across Python implementations.
+
+Compares:
+- CPython 3.14.2 (homebrew)
+- CPython 3.15.0a4 (latest alpha)
+- PyPy 3.10.16
+- Go (json2xml-go)
+
+Each Python version gets its own virtual environment with json2xml installed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Configuration
+BASE_DIR = Path(__file__).resolve().parent
+VENVS_DIR = BASE_DIR / ".benchmark_venvs"
+GO_CLI = Path(os.environ.get("JSON2XML_GO_CLI", "json2xml-go"))
+
+# Python implementations to benchmark
+PYTHON_VERSIONS = [
+    {
+        "name": "CPython 3.14.2",
+        "python": "/opt/homebrew/bin/python3.14",
+        "venv_name": "venv_cpython314_2",
+    },
+    {
+        "name": "CPython 3.15.0a4",
+        "python": str(Path.home() / ".local/share/uv/python/cpython-3.15.0a4-macos-aarch64-none/bin/python3.15"),
+        "venv_name": "venv_cpython315a4",
+    },
+    {
+        "name": "PyPy 3.10.16",
+        "python": str(Path.home() / ".local/share/uv/python/pypy-3.10.19-macos-aarch64-none/bin/pypy3.10"),
+        "venv_name": "venv_pypy310",
+    },
+]
+
+
+# Colors for terminal output
+class Colors:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    BLUE = "\033[0;34m"
+    YELLOW = "\033[1;33m"
+    CYAN = "\033[0;36m"
+    MAGENTA = "\033[0;35m"
+    BOLD = "\033[1m"
+    NC = "\033[0m"
+
+
+def colorize(text: str, color: str) -> str:
+    """Wrap text in color codes."""
+    return f"{color}{text}{Colors.NC}"
+
+
+def random_string(length: int = 10) -> str:
+    """Generate a random string."""
+    return "".join(random.choices(string.ascii_letters, k=length))
+
+
+def generate_test_json(num_records: int = 1000) -> str:
+    """Generate a JSON file for benchmarking."""
+    data = []
+    for i in range(num_records):
+        item = {
+            "id": i,
+            "name": random_string(20),
+            "email": f"{random_string(8)}@example.com",
+            "active": random.choice([True, False]),
+            "score": round(random.uniform(0, 100), 2),
+            "tags": [random_string(5) for _ in range(5)],
+            "metadata": {
+                "created": "2024-01-15T10:30:00Z",
+                "updated": "2024-01-15T12:45:00Z",
+                "version": random.randint(1, 100),
+                "nested": {
+                    "level1": {
+                        "level2": {"value": random_string(10)}
+                    }
+                },
+            },
+        }
+        data.append(item)
+    return json.dumps(data)
+
+
+@dataclass
+class BenchmarkResult:
+    """Holds benchmark timing results."""
+    name: str
+    avg_ms: float
+    min_ms: float
+    max_ms: float
+    success: bool
+    error: str = ""
+
+
+def setup_venv(python_path: str, venv_path: Path) -> bool:
+    """Create a virtual environment and install json2xml."""
+    if not Path(python_path).exists():
+        print(f"  {colorize('✗', Colors.RED)} Python not found: {python_path}")
+        return False
+
+    # Create venv if it doesn't exist or is broken
+    venv_python = venv_path / "bin" / "python"
+    if not venv_python.exists():
+        print(f"  Creating venv at {venv_path}...")
+        result = subprocess.run(
+            [python_path, "-m", "venv", str(venv_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(f"  {colorize('✗', Colors.RED)} Failed to create venv: {result.stderr}")
+            return False
+
+        # Install json2xml in the venv
+        print(f"  Installing json2xml...")
+        pip_path = venv_path / "bin" / "pip"
+        result = subprocess.run(
+            [str(pip_path), "install", "-e", str(BASE_DIR), "-q"],
+            capture_output=True,
+            text=True,
+            cwd=str(BASE_DIR),
+        )
+        if result.returncode != 0:
+            print(f"  {colorize('✗', Colors.RED)} Failed to install json2xml: {result.stderr}")
+            return False
+
+    return True
+
+
+def run_benchmark(
+    cmd: list[str],
+    iterations: int = 10,
+    warmup: int = 2,
+) -> BenchmarkResult:
+    """Run a benchmark for the given command."""
+    times = []
+
+    # Check if command exists
+    if not Path(cmd[0]).exists() and not shutil.which(cmd[0]):
+        return BenchmarkResult(
+            name="",
+            avg_ms=0,
+            min_ms=0,
+            max_ms=0,
+            success=False,
+            error=f"Command not found: {cmd[0]}",
+        )
+
+    # Warmup runs
+    for _ in range(warmup):
+        result = subprocess.run(cmd, capture_output=True, check=False)
+        if result.returncode != 0:
+            return BenchmarkResult(
+                name="",
+                avg_ms=0,
+                min_ms=0,
+                max_ms=0,
+                success=False,
+                error=result.stderr.decode()[:100],
+            )
+
+    # Timed runs
+    for _ in range(iterations):
+        start = time.perf_counter()
+        result = subprocess.run(cmd, capture_output=True, check=False)
+        end = time.perf_counter()
+
+        if result.returncode != 0:
+            return BenchmarkResult(
+                name="",
+                avg_ms=0,
+                min_ms=0,
+                max_ms=0,
+                success=False,
+                error=result.stderr.decode()[:100],
+            )
+
+        duration_ms = (end - start) * 1000
+        times.append(duration_ms)
+
+    return BenchmarkResult(
+        name="",
+        avg_ms=sum(times) / len(times),
+        min_ms=min(times),
+        max_ms=max(times),
+        success=True,
+    )
+
+
+def format_time(ms: float) -> str:
+    """Format time in milliseconds."""
+    if ms < 1:
+        return f"{ms * 1000:.2f}µs"
+    elif ms < 1000:
+        return f"{ms:.2f}ms"
+    else:
+        return f"{ms / 1000:.2f}s"
+
+
+def print_header(title: str) -> None:
+    """Print a section header."""
+    print(colorize("=" * 70, Colors.BLUE))
+    print(colorize(f"  {title}", Colors.BOLD))
+    print(colorize("=" * 70, Colors.BLUE))
+
+
+def print_table_row(name: str, result: BenchmarkResult, baseline_ms: float | None = None) -> None:
+    """Print a formatted table row."""
+    if not result.success:
+        print(f"  {name:<35} {colorize('FAILED', Colors.RED)}: {result.error}")
+        return
+
+    speedup_str = ""
+    if baseline_ms and result.avg_ms > 0:
+        speedup = baseline_ms / result.avg_ms
+        if speedup > 1:
+            speedup_str = colorize(f" ({speedup:.1f}x faster)", Colors.GREEN)
+        else:
+            speedup_str = f" ({1/speedup:.1f}x slower)"
+
+    print(f"  {name:<35} {format_time(result.avg_ms):>12} "
+          f"(min: {format_time(result.min_ms)}, max: {format_time(result.max_ms)}){speedup_str}")
+
+
+def main() -> int:
+    """Run the multi-Python benchmark suite."""
+    print_header("Multi-Python Benchmark: json2xml Performance")
+    print()
+
+    # Create venvs directory
+    VENVS_DIR.mkdir(exist_ok=True)
+
+    # Setup phase
+    print(colorize("Setting up Python environments...", Colors.YELLOW))
+    print()
+
+    active_pythons = []
+    for py_config in PYTHON_VERSIONS:
+        name = py_config["name"]
+        python_path = py_config["python"]
+        venv_name = py_config["venv_name"]
+        venv_path = VENVS_DIR / venv_name
+
+        print(f"  {name}:")
+        if setup_venv(python_path, venv_path):
+            print(f"    {colorize('✓', Colors.GREEN)} Ready")
+            active_pythons.append({
+                **py_config,
+                "venv_path": venv_path,
+                "cli_python": str(venv_path / "bin" / "python"),
+            })
+        else:
+            print(f"    {colorize('✗', Colors.RED)} Skipped")
+        print()
+
+    # Check Go CLI
+    go_available = shutil.which(str(GO_CLI)) is not None or Path(GO_CLI).exists()
+    if go_available:
+        print(f"  Go (json2xml-go): {colorize('✓', Colors.GREEN)} Ready")
+    else:
+        print(f"  Go (json2xml-go): {colorize('✗', Colors.RED)} Not found at {GO_CLI}")
+        print(f"    Set JSON2XML_GO_CLI env var or ensure json2xml-go is in PATH")
+    print()
+
+    if not active_pythons:
+        print(colorize("Error: No Python environments available!", Colors.RED))
+        return 1
+
+    # Generate test files
+    print(colorize("Generating test data...", Colors.YELLOW))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Small JSON
+        small_json = '{"name": "John", "age": 30, "city": "New York"}'
+
+        # Medium JSON (existing file)
+        medium_json_file = BASE_DIR / "examples" / "bigexample.json"
+
+        # Large JSON
+        large_json = generate_test_json(1000)
+        large_json_file = Path(tmpdir) / "large.json"
+        large_json_file.write_text(large_json)
+
+        # Very large JSON
+        very_large_json = generate_test_json(5000)
+        very_large_json_file = Path(tmpdir) / "very_large.json"
+        very_large_json_file.write_text(very_large_json)
+
+        print(f"  Small:      {len(small_json):,} bytes")
+        print(f"  Medium:     {medium_json_file.stat().st_size:,} bytes")
+        print(f"  Large:      {large_json_file.stat().st_size:,} bytes (1000 records)")
+        print(f"  Very Large: {very_large_json_file.stat().st_size:,} bytes (5000 records)")
+        print()
+
+        iterations = 10
+        all_results: dict[str, dict[str, BenchmarkResult]] = {}
+
+        # Benchmark each test case
+        test_cases = [
+            ("Small JSON", ["-s", small_json]),
+            ("Medium JSON", [str(medium_json_file)]),
+            ("Large JSON (1K)", [str(large_json_file)]),
+            ("Very Large JSON (5K)", [str(very_large_json_file)]),
+        ]
+
+        for test_name, args in test_cases:
+            print_header(f"Benchmark: {test_name}")
+            print()
+
+            results: dict[str, BenchmarkResult] = {}
+
+            # Benchmark each Python version
+            for py_config in active_pythons:
+                name = py_config["name"]
+                cli_python = py_config["cli_python"]
+                cmd = [cli_python, "-m", "json2xml.cli"] + args
+
+                result = run_benchmark(cmd, iterations=iterations)
+                result.name = name
+                results[name] = result
+
+            # Benchmark Go
+            if go_available:
+                go_cmd = [str(GO_CLI)] + args
+                go_result = run_benchmark(go_cmd, iterations=iterations)
+                go_result.name = "Go (json2xml-go)"
+                results["Go"] = go_result
+
+            all_results[test_name] = results
+
+            # Find baseline (first successful Python result)
+            baseline_ms = None
+            for py_config in active_pythons:
+                if results.get(py_config["name"], BenchmarkResult("", 0, 0, 0, False)).success:
+                    baseline_ms = results[py_config["name"]].avg_ms
+                    break
+
+            # Print results
+            for py_config in active_pythons:
+                name = py_config["name"]
+                if name in results:
+                    print_table_row(name, results[name], baseline_ms)
+
+            if go_available and "Go" in results:
+                print_table_row("Go (json2xml-go)", results["Go"], baseline_ms)
+
+            print()
+
+        # Summary
+        print_header("SUMMARY: Average Times Across All Tests")
+        print()
+
+        # Calculate averages
+        avg_times: dict[str, list[float]] = {}
+        for test_name, results in all_results.items():
+            for name, result in results.items():
+                if result.success:
+                    if name not in avg_times:
+                        avg_times[name] = []
+                    avg_times[name].append(result.avg_ms)
+
+        # Print summary table
+        print(f"  {'Implementation':<35} {'Avg Time':>12} {'vs CPython 3.14.2':>20}")
+        print(f"  {'-' * 35} {'-' * 12} {'-' * 20}")
+
+        baseline_name = "CPython 3.14.2"
+        baseline_avg = sum(avg_times.get(baseline_name, [0])) / len(avg_times.get(baseline_name, [1]))
+
+        sorted_impls = sorted(avg_times.items(), key=lambda x: sum(x[1]) / len(x[1]))
+
+        for name, times in sorted_impls:
+            avg = sum(times) / len(times)
+            if baseline_avg > 0 and name != baseline_name:
+                speedup = baseline_avg / avg
+                if speedup > 1:
+                    vs_baseline = colorize(f"{speedup:.2f}x faster", Colors.GREEN)
+                else:
+                    vs_baseline = f"{1/speedup:.2f}x slower"
+            else:
+                vs_baseline = "baseline"
+
+            print(f"  {name:<35} {format_time(avg):>12} {vs_baseline:>20}")
+
+        print()
+        print(colorize("=" * 70, Colors.BLUE))
+        print(colorize("Benchmark complete!", Colors.GREEN))
+        print(colorize("=" * 70, Colors.BLUE))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -1,0 +1,221 @@
+Benchmarks
+==========
+
+Comprehensive performance comparison between Python implementations and the Go version of json2xml.
+
+Test Environment
+----------------
+
+* **Machine**: Apple Silicon (aarch64)
+* **OS**: macOS
+* **Date**: January 14, 2026
+
+Implementations Tested
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Implementation
+     - Version
+     - Notes
+   * - CPython
+     - 3.14.2
+     - Homebrew installation
+   * - CPython
+     - 3.15.0a4
+     - Latest alpha via uv
+   * - PyPy
+     - 3.10.16
+     - JIT-compiled Python
+   * - Go
+     - 1.0.0
+     - json2xml-go
+
+Test Data
+~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 50 30
+
+   * - Size
+     - Description
+     - Bytes
+   * - Small
+     - Simple object ``{"name": "John", "age": 30, "city": "New York"}``
+     - 47
+   * - Medium
+     - ``bigexample.json`` (patent data)
+     - 2,598
+   * - Large
+     - 1,000 generated records with nested structures
+     - 323,130
+   * - Very Large
+     - 5,000 generated records with nested structures
+     - 1,619,991
+
+Results
+-------
+
+Individual Test Results
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 20 20 15
+
+   * - Test
+     - CPython 3.14.2
+     - CPython 3.15.0a4
+     - PyPy 3.10.16
+     - Go
+   * - **Small JSON** (47 bytes)
+     - 75.46ms
+     - 55.74ms (1.4x faster)
+     - 121.47ms (1.6x slower)
+     - 3.69ms (20.4x faster)
+   * - **Medium JSON** (2.6KB)
+     - 73.87ms
+     - 57.98ms (1.3x faster)
+     - 125.73ms (1.7x slower)
+     - 4.32ms (17.1x faster)
+   * - **Large JSON** (323KB)
+     - 419.67ms
+     - 328.98ms (1.3x faster)
+     - 517.51ms (1.2x slower)
+     - 67.13ms (6.3x faster)
+   * - **Very Large JSON** (1.6MB)
+     - 2.09s
+     - 1.86s (1.1x faster)
+     - 1.42s (1.5x faster)
+     - 287.58ms (7.3x faster)
+
+Summary (Average Across All Tests)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Implementation
+     - Avg Time
+     - vs CPython 3.14.2
+   * - **Go**
+     - 90.68ms
+     - **7.34x faster** 🚀
+   * - **PyPy 3.10.16**
+     - 545.58ms
+     - **1.22x faster**
+   * - **CPython 3.15.0a4**
+     - 575.45ms
+     - **1.16x faster**
+   * - **CPython 3.14.2**
+     - 665.23ms
+     - baseline
+
+Key Observations
+----------------
+
+1. Go is the Clear Winner
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Go outperforms all Python implementations by a significant margin:
+
+* **7.34x faster** than CPython 3.14.2 on average
+* Up to **20x faster** for small inputs due to minimal startup overhead
+* Consistent performance across all input sizes
+
+2. CPython 3.15.0a4 Shows Promising Improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The latest Python alpha demonstrates consistent performance gains:
+
+* **13-35% faster** than CPython 3.14.2 across all test sizes
+* Improvements likely due to ongoing interpreter optimizations
+
+3. PyPy Has Interesting Trade-offs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PyPy's JIT compiler creates a unique performance profile:
+
+* **Slower for small/medium inputs**: JIT compilation overhead hurts for quick operations
+* **Faster for very large inputs**: JIT shines on the 5K record test (1.5x faster than CPython)
+* Best suited for long-running processes or batch processing
+
+4. Startup Overhead Dominates Small Inputs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Python's interpreter startup time is significant:
+
+* CPython takes **55-75ms** even for 47 bytes of JSON
+* Go takes only **3.7ms** for the same operation
+* For CLI tools processing small files, Go provides a much better user experience
+
+When to Use Each Implementation
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Use Case
+     - Recommended
+   * - CLI tool for small/medium files
+     - **Go** (json2xml-go)
+   * - High-throughput batch processing
+     - **Go** or **PyPy**
+   * - Integration with Python codebase
+     - **CPython 3.15+**
+   * - One-off conversions in scripts
+     - **CPython** (any version)
+
+Running the Benchmarks
+----------------------
+
+Python Multi-Implementation Benchmark
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Set the Go CLI path
+   export JSON2XML_GO_CLI=/path/to/json2xml-go
+
+   # Run the benchmark
+   python benchmark_multi_python.py
+
+Simple Python vs Go Benchmark
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Set paths via environment variables (optional)
+   export JSON2XML_GO_CLI=/path/to/json2xml-go
+   export JSON2XML_EXAMPLES_DIR=/path/to/examples
+
+   # Run the benchmark
+   python benchmark.py
+
+Reproducing Results
+-------------------
+
+1. Install required Python versions using ``uv``:
+
+   .. code-block:: bash
+
+      uv python install 3.14 3.15.0a4 pypy@3.10
+
+2. Build the Go binary:
+
+   .. code-block:: bash
+
+      cd /path/to/json2xml-go
+      go build -o json2xml-go ./cmd/json2xml-go
+
+3. Run the multi-Python benchmark:
+
+   .. code-block:: bash
+
+      cd /path/to/json2xml
+      python benchmark_multi_python.py

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to json2xml's documentation!
    readme
    installation
    usage
+   benchmarks
    modules
    contributing
    authors

--- a/json2xml/cli.py
+++ b/json2xml/cli.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+json2xml-py - Command-line tool to convert JSON data to XML format.
+
+Usage:
+    json2xml-py [flags] [input-file]
+
+Flags:
+    -w, --wrapper string    Wrapper element name (default "all")
+    -r, --root              Include root element (default true)
+    -p, --pretty            Pretty print output (default true)
+    -t, --type              Include type attributes (default true)
+    -i, --item-wrap         Wrap list items in <item> elements (default true)
+    -x, --xpath             Use XPath 3.1 json-to-xml format
+    -o, --output string     Output file (default: stdout)
+    -u, --url string        Read JSON from URL
+    -s, --string string     Read JSON from string
+    -c, --cdata             Wrap string values in CDATA sections
+    -l, --list-headers      Repeat headers for each list item
+    -h, --help              Show help message
+    -v, --version           Show version information
+
+Examples:
+    # Convert a JSON file to XML
+    json2xml-py data.json
+
+    # Convert with custom wrapper
+    json2xml-py -w root data.json
+
+    # Read from URL
+    json2xml-py -u https://api.example.com/data.json
+
+    # Read from string
+    json2xml-py -s '{"name": "John", "age": 30}'
+
+    # Output to file
+    json2xml-py -o output.xml data.json
+
+    # Use XPath 3.1 format
+    json2xml-py -x data.json
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from json2xml import __version__
+from json2xml.json2xml import Json2xml
+from json2xml.utils import (
+    JSONReadError,
+    StringReadError,
+    URLReadError,
+    readfromjson,
+    readfromstring,
+    readfromurl,
+)
+
+AUTHOR = "Vinit Kumar"
+EMAIL = "mail@vinitkumar.me"
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create and configure the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="json2xml-py",
+        description="Convert JSON to XML",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  # Convert a JSON file to XML
+  json2xml-py data.json
+
+  # Convert with custom wrapper
+  json2xml-py -w root data.json
+
+  # Read from URL
+  json2xml-py -u https://api.example.com/data.json
+
+  # Read from string
+  json2xml-py -s '{"name": "John", "age": 30}'
+
+  # Read from stdin
+  cat data.json | json2xml-py -
+
+  # Output to file
+  json2xml-py -o output.xml data.json
+
+  # Use XPath 3.1 format
+  json2xml-py -x data.json
+
+  # Disable pretty printing and type attributes
+  json2xml-py --no-pretty --no-type data.json
+""",
+    )
+
+    # Input options
+    input_group = parser.add_argument_group("Input Options")
+    input_group.add_argument(
+        "input_file",
+        nargs="?",
+        default=None,
+        help="Read JSON from file (use - for stdin)",
+    )
+    input_group.add_argument(
+        "-u",
+        "--url",
+        dest="url",
+        default=None,
+        help="Read JSON from URL",
+    )
+    input_group.add_argument(
+        "-s",
+        "--string",
+        dest="string",
+        default=None,
+        help="Read JSON from string",
+    )
+
+    # Output options
+    output_group = parser.add_argument_group("Output Options")
+    output_group.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        default=None,
+        help="Output file (default: stdout)",
+    )
+
+    # Conversion options
+    conv_group = parser.add_argument_group("Conversion Options")
+    conv_group.add_argument(
+        "-w",
+        "--wrapper",
+        dest="wrapper",
+        default="all",
+        help='Wrapper element name (default: "all")',
+    )
+    conv_group.add_argument(
+        "-r",
+        "--root",
+        dest="root",
+        action="store_true",
+        default=True,
+        help="Include root element (default: true)",
+    )
+    conv_group.add_argument(
+        "--no-root",
+        dest="root",
+        action="store_false",
+        help="Exclude root element",
+    )
+    conv_group.add_argument(
+        "-p",
+        "--pretty",
+        dest="pretty",
+        action="store_true",
+        default=True,
+        help="Pretty print output (default: true)",
+    )
+    conv_group.add_argument(
+        "--no-pretty",
+        dest="pretty",
+        action="store_false",
+        help="Disable pretty printing",
+    )
+    conv_group.add_argument(
+        "-t",
+        "--type",
+        dest="attr_type",
+        action="store_true",
+        default=True,
+        help="Include type attributes (default: true)",
+    )
+    conv_group.add_argument(
+        "--no-type",
+        dest="attr_type",
+        action="store_false",
+        help="Exclude type attributes",
+    )
+    conv_group.add_argument(
+        "-i",
+        "--item-wrap",
+        dest="item_wrap",
+        action="store_true",
+        default=True,
+        help="Wrap list items in <item> elements (default: true)",
+    )
+    conv_group.add_argument(
+        "--no-item-wrap",
+        dest="item_wrap",
+        action="store_false",
+        help="Don't wrap list items",
+    )
+    conv_group.add_argument(
+        "-x",
+        "--xpath",
+        dest="xpath_format",
+        action="store_true",
+        default=False,
+        help="Use XPath 3.1 json-to-xml format",
+    )
+    conv_group.add_argument(
+        "-c",
+        "--cdata",
+        dest="cdata",
+        action="store_true",
+        default=False,
+        help="Wrap string values in CDATA sections",
+    )
+    conv_group.add_argument(
+        "-l",
+        "--list-headers",
+        dest="list_headers",
+        action="store_true",
+        default=False,
+        help="Repeat headers for each list item",
+    )
+
+    # Other options
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"json2xml-py version {__version__}\nAuthor: {AUTHOR} <{EMAIL}>",
+    )
+
+    return parser
+
+
+def read_input(args: argparse.Namespace) -> dict[str, Any] | list[Any]:
+    """
+    Read JSON input from the specified source.
+
+    Priority: URL > String > File > Stdin
+
+    Args:
+        args: Parsed command line arguments.
+
+    Returns:
+        Parsed JSON data as dict or list.
+
+    Raises:
+        SystemExit: When no input is provided or reading fails.
+    """
+    # Priority: URL > String > File > Stdin
+    if args.url:
+        try:
+            return readfromurl(args.url)
+        except URLReadError as e:
+            print(f"Error reading from URL: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.string:
+        try:
+            return readfromstring(args.string)
+        except StringReadError as e:
+            print(f"Error parsing JSON string: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.input_file:
+        if args.input_file == "-":
+            # Read from stdin
+            return read_from_stdin()
+        try:
+            return readfromjson(args.input_file)
+        except JSONReadError as e:
+            print(f"Error reading JSON file: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Check if there's data on stdin
+    if not sys.stdin.isatty():
+        return read_from_stdin()
+
+    print("Error: No input provided. Use -h for help.", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_from_stdin() -> dict[str, Any] | list[Any]:
+    """
+    Read JSON from standard input.
+
+    Returns:
+        Parsed JSON data.
+
+    Raises:
+        SystemExit: When stdin is empty or contains invalid JSON.
+    """
+    try:
+        json_str = sys.stdin.read().strip()
+        if not json_str:
+            print("Error: Empty input", file=sys.stderr)
+            sys.exit(1)
+        return readfromstring(json_str)
+    except StringReadError as e:
+        print(f"Error parsing JSON from stdin: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_output(output: str | bytes, output_file: str | None) -> None:
+    """
+    Write XML output to the specified destination.
+
+    Args:
+        output: XML content to write.
+        output_file: Path to output file, or None for stdout.
+    """
+    if isinstance(output, bytes):
+        output = output.decode("utf-8")
+
+    if output_file:
+        try:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(output)
+        except OSError as e:
+            print(f"Error writing to file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(output)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    Main entry point for the CLI.
+
+    Args:
+        argv: Command line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    # Read input data
+    try:
+        data = read_input(args)
+    except Exception as e:
+        print(f"Error reading input: {e}", file=sys.stderr)
+        return 1
+
+    # Convert to XML
+    try:
+        converter = Json2xml(
+            data=data,
+            wrapper=args.wrapper,
+            root=args.root,
+            pretty=args.pretty,
+            attr_type=args.attr_type,
+            item_wrap=args.item_wrap,
+            xpath_format=args.xpath_format,
+        )
+        xml_output = converter.to_xml()
+
+        if xml_output is None:
+            print("Error: Empty data, no XML generated", file=sys.stderr)
+            return 1
+
+        write_output(xml_output, args.output)
+
+    except Exception as e:
+        print(f"Error converting to XML: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/json2xml/cli.py
+++ b/json2xml/cli.py
@@ -349,6 +349,8 @@ def main(argv: list[str] | None = None) -> int:
             attr_type=args.attr_type,
             item_wrap=args.item_wrap,
             xpath_format=args.xpath_format,
+            cdata=args.cdata,
+            list_headers=args.list_headers,
         )
         xml_output = converter.to_xml()
 

--- a/json2xml/json2xml.py
+++ b/json2xml/json2xml.py
@@ -21,6 +21,8 @@ class Json2xml:
         attr_type: bool = True,
         item_wrap: bool = True,
         xpath_format: bool = False,
+        cdata: bool = False,
+        list_headers: bool = False,
     ):
         self.data = data
         self.pretty = pretty
@@ -29,6 +31,8 @@ class Json2xml:
         self.root = root
         self.item_wrap = item_wrap
         self.xpath_format = xpath_format
+        self.cdata = cdata
+        self.list_headers = list_headers
 
     def to_xml(self) -> Any | None:
         """
@@ -42,6 +46,8 @@ class Json2xml:
                 attr_type=self.attr_type,
                 item_wrap=self.item_wrap,
                 xpath_format=self.xpath_format,
+                cdata=self.cdata,
+                list_headers=self.list_headers,
             )
             if self.pretty:
                 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/vinitkumar/json2xml"
 
+[project.scripts]
+json2xml-py = "json2xml.cli:main"
+
 [tool.setuptools.packages.find]
 include = ["json2xml"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,225 @@
+"""Tests for the json2xml CLI."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest import CaptureFixture
+
+
+class TestCLI:
+    """Test cases for the CLI module."""
+
+    def test_help_flag(self) -> None:
+        """Test --help flag shows usage information."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "json2xml-py" in result.stdout
+        assert "Convert JSON to XML" in result.stdout
+
+    def test_version_flag(self) -> None:
+        """Test --version flag shows version information."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "--version"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "json2xml-py version" in result.stdout
+        assert "Vinit Kumar" in result.stdout
+
+    def test_string_input(self) -> None:
+        """Test -s/--string flag for inline JSON."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-s", '{"name": "John"}'],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "<name" in result.stdout
+        assert "John" in result.stdout
+
+    def test_file_input(self) -> None:
+        """Test file input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_file = Path(tmpdir) / "test.json"
+            json_file.write_text('{"key": "value"}')
+
+            result = subprocess.run(
+                [sys.executable, "-m", "json2xml.cli", str(json_file)],
+                capture_output=True,
+                text=True,
+            )
+
+        assert result.returncode == 0
+        assert "<key" in result.stdout
+        assert "value" in result.stdout
+
+    def test_output_file(self) -> None:
+        """Test -o/--output flag for file output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = Path(tmpdir) / "output.xml"
+
+            result = subprocess.run(
+                [
+                    sys.executable, "-m", "json2xml.cli",
+                    "-s", '{"test": "data"}',
+                    "-o", str(output_file),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            assert result.returncode == 0
+            assert output_file.exists()
+            content = output_file.read_text()
+            assert "<test" in content
+            assert "data" in content
+
+    def test_wrapper_option(self) -> None:
+        """Test -w/--wrapper flag for custom wrapper element."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '{"name": "John"}',
+                "-w", "root",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "<root>" in result.stdout
+
+    def test_no_root_option(self) -> None:
+        """Test --no-root flag."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '{"name": "John"}',
+                "--no-root",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # Without root, there should be no wrapper element
+        assert "<all>" not in result.stdout
+
+    def test_no_pretty_option(self) -> None:
+        """Test --no-pretty flag disables pretty printing."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '{"name": "John"}',
+                "--no-pretty",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # Output should be XML on a single line (not indented)
+        # Pretty mode adds newlines and indentation, non-pretty is compact
+        lines = [line for line in result.stdout.strip().split("\n") if line.strip()]
+        # Non-pretty output should be more compact (typically 1-2 lines)
+        assert len(lines) <= 2
+        assert "<name" in result.stdout
+
+    def test_no_type_option(self) -> None:
+        """Test --no-type flag excludes type attributes."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '{"name": "John", "age": 30}',
+                "--no-type",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert 'type="str"' not in result.stdout
+        assert 'type="int"' not in result.stdout
+
+    def test_xpath_format(self) -> None:
+        """Test -x/--xpath flag for XPath 3.1 format."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '{"name": "John"}',
+                "-x",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "http://www.w3.org/2005/xpath-functions" in result.stdout
+
+    def test_stdin_input(self) -> None:
+        """Test reading from stdin with - argument."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-"],
+            input='{"stdin": "test"}',
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "<stdin" in result.stdout
+        assert "test" in result.stdout
+
+    def test_invalid_json_string(self) -> None:
+        """Test error handling for invalid JSON string."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-s", "not valid json"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+    def test_no_input_error(self) -> None:
+        """Test error when no input is provided."""
+        # Force isatty to return True by using a pty-like environment
+        # For now, just test with explicit empty args
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli"],
+            capture_output=True,
+            text=True,
+            input="",  # Empty stdin
+        )
+        # Should fail with no input error
+        assert result.returncode == 1
+
+    def test_list_input(self) -> None:
+        """Test handling of JSON array input."""
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "json2xml.cli",
+                "-s", '[1, 2, 3]',
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "<item" in result.stdout
+
+    def test_nested_json(self) -> None:
+        """Test handling of nested JSON structures."""
+        nested_json = '{"outer": {"inner": {"value": 42}}}'
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-s", nested_json],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "<outer" in result.stdout
+        assert "<inner" in result.stdout
+        assert "42" in result.stdout


### PR DESCRIPTION
- Add json2xml/cli.py with same flags as Go version
- Add console script entry point as json2xml-py
- Add comprehensive CLI tests (15 tests)
- Add benchmark scripts to compare Python vs Go performance

Flags: -w/--wrapper, -r/--root, -p/--pretty, -t/--type,
       -i/--item-wrap, -x/--xpath, -c/--cdata, -l/--list-headers,
       -u/--url, -s/--string, -o/--output, -v/--version, -h/--help

## Summary by Sourcery

Add a Python command-line interface for json2xml with parity to the Go tool and supporting scripts.

New Features:
- Introduce a dedicated CLI module exposing a json2xml-py command with flexible input, output, and conversion options.
- Provide benchmarking utilities to compare Python and Go json2xml performance across different input sizes.

Build:
- Expose the CLI via a console script entry point in the project configuration.

Tests:
- Add an automated test suite for the CLI covering flags, input modes, output handling, and error conditions.