### PR TITLE
fix: remove needless line

### DIFF
--- a/json2xml/dicttoxml.py
+++ b/json2xml/dicttoxml.py
@@ -341,7 +341,6 @@ def dict2xml_str(
     parse dict2xml
     """
     ids: list[str] = []  # initialize list of unique ids
-    ", ".join(str(key) for key in item)
     subtree = ""  # Initialize subtree with default empty string
 
     if attr_type:


### PR DESCRIPTION
Line 344 in dicttoxml.py was superfluous resp. a relict from delete commit a 3 years ago.

## Summary by Sourcery

Bug Fixes:
- Eliminate a superfluous line in dict2xml_str that performed a no-op join operation.