### PR TITLE
chore: release v6.0.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,11 @@
 
+6.0.7 / 2026-04-26
+==================
+
+  * fix: handle JSON conversion edge cases and improve URL reader robustness (#284)
+  * chore(deps-dev): bump pytest from 9.0.1 to 9.0.3 (#282)
+
+
 6.0.6 / 2026-04-08
 ==================
 

--- a/json2xml/__init__.py
+++ b/json2xml/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Vinit Kumar"""
 __email__ = "mail@vinitkumar.me"
-__version__ = "6.0.6"
+__version__ = "6.0.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "json2xml"
-version = "6.0.6"
+version = "6.0.7"
 description = "Simple Python Library to convert JSON to XML"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 6.0.7
 commit = True
 tag = True
 

--- a/uv.lock
+++ b/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "json2xml"
-version = "6.0.6"
+version = "6.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary by Sourcery

Prepare the project for the 6.0.7 release.

Build:
- Update package version metadata to 6.0.7 in project configuration files.

Chores:
- Align bumpversion configuration with the new 6.0.7 release version.
- Refresh generated or lock files for the new release.