### PR TITLE
Fix uv audit vulnerabilities

### DIFF
--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -28,6 +28,12 @@ The April 2026 benchmark on Apple Silicon shows the Rust extension as the best o
 
 Reproduction docs require contributors to record machine, OS, Python, and tool availability before comparing results. `benchmark_all.py` mixes library calls and CLI subprocesses intentionally, so its Go and Zig rows include process startup overhead.
 
+## Dependency security
+
+Dependency floors and lockfiles keep known vulnerable packages out of runtime and development environments.
+
+Runtime dependencies are declared in `pyproject.toml` and mirrored by `uv.lock`; legacy requirements inputs remain pinned for tooling that still consumes requirements files. Security fixes should update both resolver paths so `uv audit` and requirements-based installs agree.
+
 ## CLI entrypoint
 
 The CLI is a thin adapter that parses options, resolves one input source, and forwards those options into the same converter used by the library API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "defusedxml",
-    "urllib3",
+    "urllib3>=2.7.0",
 ]
 
 [project.urls]
@@ -47,6 +47,7 @@ dev = [
     "pytest-cov",
     "coverage",
     "setuptools",
+    "pygments>=2.20.0",
     "xmltodict>=0.12.0",
 ]
 fast = ["json2xml-rs>=0.1.0"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,4 +7,5 @@ pytest-xdist>=3.8.0
 coverage>=7.10.3
 ruff>=0.12.8
 setuptools>=80.9.0
+pygments>=2.20.0
 # Note: ty is run via uvx, not installed as a dependency

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pluggy==1.5.0
     # via
     #   pytest
     #   pytest-cov
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pytest==9.0.3
     # via
@@ -43,7 +43,7 @@ tomli==2.4.1
     #   pytest
 typing-extensions==4.15.0
     # via exceptiongroup
-urllib3==2.6.3
+urllib3==2.7.0
     # via -r requirements.in
 xmltodict==0.14.2
     # via -r requirements-dev.in

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 defusedxml==0.7.1
-urllib3==2.6.3
+urllib3==2.7.0
 

--- a/uv.lock
+++ b/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "json2xml"
-version = "6.0.7"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
@@ -157,6 +157,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "setuptools" },
@@ -171,10 +172,11 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "defusedxml" },
     { name = "json2xml-rs", marker = "extra == 'fast'", specifier = ">=0.1.0" },
+    { name = "pygments", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.1" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "setuptools", marker = "extra == 'dev'" },
-    { name = "urllib3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "xmltodict", marker = "extra == 'dev'", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev", "fast"]
@@ -234,11 +236,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -342,11 +344,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Address dependency security vulnerabilities and document the project’s dependency management approach.

Bug Fixes:
- Raise the minimum urllib3 version and align lockfiles/requirements to avoid known security vulnerabilities.
- Pin Pygments as a development dependency at a secure minimum version to mitigate reported issues.

Enhancements:
- Keep runtime, lockfile, and legacy requirements inputs in sync for both uv- and requirements-based workflows.

Documentation:
- Document the project’s dependency security strategy, including dependency floors, lockfiles, and alignment between uv and requirements-based installs.