### PR TITLE
Fix Rust release workflow toolchain

### DIFF
--- a/.github/workflows/build-rust-wheels.yml
+++ b/.github/workflows/build-rust-wheels.yml
@@ -15,6 +15,7 @@ on:
 env:
   PACKAGE_NAME: json2xml_rs
   PYTHON_VERSION: '3.12'
+  RUST_VERSION: '1.96.0'
 
 permissions:
   contents: read
@@ -32,6 +33,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -62,6 +68,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.target }}
 
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
@@ -89,6 +100,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
@@ -108,6 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_VERSION: '1.96.0'
 
 permissions:
   contents: read
@@ -31,6 +32,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
 
       - name: Check formatting
@@ -43,7 +45,7 @@ jobs:
 
       - name: Run Rust unit tests
         working-directory: rust
-        run: cargo test --no-default-features
+        run: cargo test
 
   rust-test:
     name: Build & Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -63,6 +65,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install maturin
         run: pip install maturin
@@ -107,6 +111,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install maturin
         run: pip install maturin

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -28,6 +28,8 @@ The Rust extension crate targets the Rust 2024 edition and pins `rust-version` t
 
 The Cargo feature layout separates normal Rust/PyO3 tests from extension-module builds. `cargo test` uses the default `python` feature without extension-module linking, while maturin enables the `extension-module` feature for wheel builds.
 
+Release and CI workflows install the pinned Rust toolchain before building wheels or running Rust checks, so hosted runners do not silently use an older default compiler.
+
 ## Release packaging
 
 Package releases keep the Python wrapper and Rust accelerator versioned together so optional fast installs receive compatible wheels.


### PR DESCRIPTION
## Summary
- install Rust 1.96.0 explicitly in the Rust wheel release workflow
- install the same Rust toolchain in Rust CI
- switch Rust CI unit tests to the fixed plain `cargo test` path
- document that CI and release workflows use the pinned Rust toolchain

## Why
The `rust-v0.3.0` release workflow failed because GitHub-hosted runners defaulted to rustc 1.95.0, while `json2xml_rs` 0.3.0 correctly requires rustc 1.96. The release workflow needs to install the crate's pinned toolchain before maturin builds wheels.

## Validation
- `cargo fmt --check`
- `cargo test`: 46 passed
- `lat check`: passed

## Summary by Sourcery

Pin the Rust toolchain version in CI and release workflows to ensure consistent builds and tests with the crate’s required compiler version.

Build:
- Update Rust wheel and sdist build workflows to install a pinned Rust 1.96.0 toolchain before running maturin.

CI:
- Configure Rust CI workflows to install a pinned Rust 1.96.0 toolchain and run unit tests with plain `cargo test`.

Documentation:
- Document that CI and release workflows install the pinned Rust toolchain to avoid using older default compilers.