### PR TITLE
Fix Rust PyPI trusted publishing permission

### DIFF
--- a/.github/workflows/build-rust-wheels.yml
+++ b/.github/workflows/build-rust-wheels.yml
@@ -19,6 +19,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   # Build wheels for Linux


### PR DESCRIPTION
## Summary
- add `id-token: write` to the Rust wheel release workflow permissions

## Why
The `rust-v0.3.0` release built all wheels successfully, but the PyPI publish job failed during trusted publishing because the workflow did not grant OIDC token permissions.

## Validation
- `lat check`: passed

## Summary by Sourcery

Build:
- Update Rust wheel build workflow permissions to include id-token: write for PyPI trusted publishing.