### PR TITLE
chore: release json2xml 6.3.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,14 @@
 
+6.3.0 / 2026-06-10
+==================
+
+  * feat: reduce pure Python serializer allocations in hot dict, list, and scalar paths
+  * feat: preserve XML output semantics while reusing validated element-name and attribute work
+  * perf: lower peak memory pressure for large conversions after the 6.2.0 Rust bytes-writer release
+  * docs: add hyperfine Rust memory benchmark notes with reproduction details and the measured throughput tradeoff
+  * chore: release ``json2xml-rs`` 0.4.0 and require it from ``json2xml[fast]`` for accelerated installs
+
+
 6.2.0 / 2026-06-05
 ==================
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# json2xml 6.3.0 and json2xml_rs 0.4.0
+
+Released 2026-06-10.
+
+## Highlights
+
+- Reduced allocation pressure in the pure Python serializer hot paths for dicts, lists, scalar values, XML names, and emitted attributes.
+- Kept the Python and Rust release line aligned: `json2xml[fast]` now requires `json2xml-rs>=0.4.0`.
+- Documented the Rust memory benchmark in enough detail to reproduce the 100,000-record RSS measurement and understand the throughput tradeoff.
+
+## Why Upgrade
+
+This release is focused on large conversion workloads. The 6.2.0 Rust release moved accelerator output directly into Python bytes to reduce peak serializer memory; 6.3.0 follows that with Python-side allocation reductions so fallback and unsupported-option paths also benefit.
+
+No XML shape changes are intended. Existing callers should see the same output for supported options, including invalid-name normalization, `@attrs`/`@val` handling, list wrapping, XPath mode, and pure Python fallback behavior.
+
+## Package Versions
+
+- Python package: `json2xml==6.3.0`
+- Rust accelerator package: `json2xml-rs==0.4.0`
+- Fast install: `pip install "json2xml[fast]"`
+
+## Changelog
+
+- `feat`: reduce pure Python serializer allocations in hot dict, list, and scalar paths.
+- `feat`: preserve XML output semantics while reusing validated element-name and attribute work.
+- `perf`: lower peak memory pressure for large conversions after the 6.2.0 Rust bytes-writer release.
+- `docs`: add hyperfine Rust memory benchmark notes with reproduction details and the measured throughput tradeoff.
+- `chore`: release `json2xml-rs` 0.4.0 and require it from `json2xml[fast]` for accelerated installs.
+
+## Verification
+
+The release changes are covered by the existing serializer, fast-backend, and Rust parity tests. The benchmark documentation records the measurement setup separately from the functional test suite so release consumers can reproduce performance results on their own hardware.

--- a/json2xml/__init__.py
+++ b/json2xml/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Vinit Kumar"""
 __email__ = "mail@vinitkumar.me"
-__version__ = "6.2.0"
+__version__ = "6.3.0"

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -32,9 +32,9 @@ Release and CI workflows install the pinned Rust toolchain before building wheel
 
 ## Release packaging
 
-Package releases keep the Python wrapper and Rust accelerator versioned together so optional fast installs receive compatible wheels.
+Package releases keep the Python wrapper and Rust accelerator requirements aligned so optional fast installs receive compatible wheels.
 
-The Python package version lives in `pyproject.toml` and `json2xml/__init__.py`. The Rust accelerator version lives in both `rust/Cargo.toml` and `rust/pyproject.toml`, and the Python `fast` extra should require the Rust package version that contains any expected accelerator behavior.
+The Python package version lives in `pyproject.toml` and `json2xml/__init__.py`. The Rust accelerator version lives in both `rust/Cargo.toml` and `rust/pyproject.toml`, and the Python `fast` extra should require the Rust package version that contains any expected accelerator behavior. Release notes live in `HISTORY.rst`, with the current release also summarized in `RELEASE_NOTES.md` for tag and PyPI copy.
 
 ## Performance benchmarks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "json2xml"
-version = "6.2.0"
+version = "6.3.0"
 description = "Simple Python Library to convert JSON to XML"
 readme = "README.rst"
 requires-python = ">=3.10"
@@ -50,7 +50,7 @@ dev = [
     "pygments>=2.20.0",
     "xmltodict>=0.12.0",
 ]
-fast = ["json2xml-rs>=0.3.0"]
+fast = ["json2xml-rs>=0.4.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json2xml_rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Fast native JSON to XML conversion for Python"

--- a/rust/README.md
+++ b/rust/README.md
@@ -76,9 +76,10 @@ The Rust implementation is expected to be 5-15x faster than pure Python for:
 - Type dispatch (compiled match statements vs. `isinstance()` chains)
 - String building (pre-allocated buffers vs. f-string concatenation)
 
-Version 0.3.0 writes serializer output directly into Python bytes, reducing the
+Version 0.4.0 builds on the direct Python bytes writer with lower allocation
+pressure in hot serializer paths. The previous 0.3.0 release reduced the
 measured serializer RSS delta for a 100,000-record benchmark by about 49%
-compared with the previous Rust implementation.
+compared with the earlier Rust implementation.
 
 ## Limitations
 

--- a/rust/pyproject.toml
+++ b/rust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "json2xml_rs"
-version = "0.3.0"
+version = "0.4.0"
 description = "Fast native JSON to XML conversion - Rust extension for json2xml"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
# json2xml 6.3.0 and json2xml_rs 0.4.0

Released 2026-06-10.

## Highlights

- Reduced allocation pressure in the pure Python serializer hot paths for dicts, lists, scalar values, XML names, and emitted attributes.
- Kept the Python and Rust release line aligned: `json2xml[fast]` now requires `json2xml-rs>=0.4.0`.
- Documented the Rust memory benchmark in enough detail to reproduce the 100,000-record RSS measurement and understand the throughput tradeoff.

## Why Upgrade

This release is focused on large conversion workloads. The 6.2.0 Rust release moved accelerator output directly into Python bytes to reduce peak serializer memory; 6.3.0 follows that with Python-side allocation reductions so fallback and unsupported-option paths also benefit.

No XML shape changes are intended. Existing callers should see the same output for supported options, including invalid-name normalization, `@attrs`/`@val` handling, list wrapping, XPath mode, and pure Python fallback behavior.

## Package Versions

- Python package: `json2xml==6.3.0`
- Rust accelerator package: `json2xml-rs==0.4.0`
- Fast install: `pip install "json2xml[fast]"`

## Changelog

- `feat`: reduce pure Python serializer allocations in hot dict, list, and scalar paths.
- `feat`: preserve XML output semantics while reusing validated element-name and attribute work.
- `perf`: lower peak memory pressure for large conversions after the 6.2.0 Rust bytes-writer release.
- `docs`: add hyperfine Rust memory benchmark notes with reproduction details and the measured throughput tradeoff.
- `chore`: release `json2xml-rs` 0.4.0 and require it from `json2xml[fast]` for accelerated installs.

## Verification

The release changes are covered by the existing serializer, fast-backend, and Rust parity tests. The benchmark documentation records the measurement setup separately from the functional test suite so release consumers can reproduce performance results on their own hardware.

## Summary by Sourcery

Release json2xml 6.3.0 and json2xml_rs 0.4.0 with aligned Python and Rust packages and updated performance documentation.

New Features:
- Reduce allocations in pure Python serializer hot paths while preserving existing XML output semantics.

Enhancements:
- Align the Python fast extra requirement with the new json2xml_rs 0.4.0 accelerator release.
- Clarify architecture and packaging documentation around version alignment and release notes location.
- Update Rust performance notes to describe the 0.4.0 allocator and RSS improvements over 0.3.0.

Build:
- Bump Python package version to 6.3.0 and Rust accelerator versions to 0.4.0 in project metadata.

Documentation:
- Add RELEASE_NOTES.md summarizing the 6.3.0 / 0.4.0 release, rationale, and benchmark details.