### PR TITLE
fix: align backend protocol with frozen adapters

### DIFF
--- a/json2xml/backend_selector.py
+++ b/json2xml/backend_selector.py
@@ -24,7 +24,9 @@ class ConversionRequest:
 class BackendAdapter(Protocol):
     """Small adapter seam for conversion backends."""
 
-    name: str
+    @property
+    def name(self) -> str:
+        raise NotImplementedError  # pragma: no cover
 
     def can_handle(self, request: ConversionRequest) -> bool:
         raise NotImplementedError  # pragma: no cover

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -24,6 +24,8 @@ The fast-path module prefers the Rust extension when it can preserve Python sema
 
 [[json2xml/dicttoxml_fast.py#dicttoxml]] now normalizes each call into a shared conversion request and asks a tiny backend selector seam to choose Rust or Python. The Rust adapter accepts only requests whose semantics it can preserve, namely no `ids`, custom `item_func`, XML namespaces, XPath mode, root scalar payloads, or special `@` keys.
 
+The backend adapter protocol exposes its diagnostic name as a read-only property, matching the frozen adapter implementations while still allowing selector code to inspect backend metadata.
+
 A local stub for the optional `json2xml_rs` module keeps static analysis aligned with that fallback design, so type checking still passes when the extension is not installed. This keeps fast installs fast without letting the optimized path silently change behavior.
 
 The Rust backend writes serializer output into Python's bytes writer instead of building a Rust string and copying it across the extension boundary. This keeps the fast path's peak output memory closer to the final `bytes` object.


### PR DESCRIPTION
## Summary

- model `BackendAdapter.name` as a read-only protocol property
- align the protocol with the frozen Rust and Python adapter dataclasses
- document the adapter metadata contract in `lat.md`

## Root cause

`BackendAdapter` declared `name` as a writable string attribute. The concrete adapters are frozen dataclasses, so ty correctly rejected them as protocol implementations because their `name` fields cannot be written.

## Impact

The ty typecheck passes without weakening diagnostics or changing runtime behavior.

## Validation

- `VIRTUAL_ENV="$PWD/.venv" uvx ty check json2xml tests`
- `uvx ruff check json2xml tests`
- `.venv/bin/pytest --cov=json2xml --cov-report=xml:coverage/reports/coverage.xml --cov-report=term -q tests` (312 passed, 94 skipped, 100% coverage)
- `cargo test --manifest-path rust/Cargo.toml` (46 passed)
- `lat check`

## Summary by Sourcery

Model backend adapter names as read-only protocol properties to match frozen adapter implementations and update architecture docs accordingly.

Bug Fixes:
- Make the BackendAdapter protocol compatible with frozen Rust and Python adapter implementations by exposing name as a read-only property.

Documentation:
- Document the backend adapter metadata contract and its read-only diagnostic name property in the architecture overview.