### PR TITLE
ci: restore macOS Python 3.10 release wheels

### DIFF
--- a/.github/workflows/build-rust-wheels.yml
+++ b/.github/workflows/build-rust-wheels.yml
@@ -97,6 +97,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # macos-latest no longer preinstalls 3.10, so make the oldest supported
+      # interpreter visible to maturin's --find-interpreter discovery.
+      - name: Add Python 3.10 to the build toolcache
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.10'
+
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -34,7 +34,7 @@ The Rust extension crate targets the Rust 2024 edition and pins `rust-version` t
 
 The Cargo feature layout separates normal Rust/PyO3 tests from extension-module builds. `cargo test` uses the default `python` feature without extension-module linking, while maturin enables the `extension-module` feature for wheel builds.
 
-Release and CI workflows install the pinned Rust toolchain before building wheels or running Rust checks, so hosted runners do not silently use an older default compiler.
+Release and CI workflows install the pinned Rust toolchain before building wheels or running Rust checks, so hosted runners do not silently use an older default compiler. The macOS release build also provisions Python 3.10 explicitly so maturin emits wheels for the oldest supported interpreter even when runner images omit it.
 
 ## Release packaging
 


### PR DESCRIPTION
## Summary

- provision CPython 3.10 explicitly in macOS Rust wheel builds
- keep maturin's existing multi-interpreter discovery for Python 3.10–3.14
- document why the oldest supported interpreter must not depend on runner preinstalls

## Release failure reproduced

The `rust-v0.4.2` release correctly stopped before PyPI publication because the macOS artifacts contained cp311–cp314 wheels but no cp310 wheel. The macOS/Python 3.10 installation gate rejected the artifact set with `No matching distribution found`.

## Validation

- workflow YAML parses successfully
- `lat check`
- a manual non-publishing run will validate the produced cp310 macOS wheel before merge
