### PR TITLE
chore: integrate pending dependency updates

### DIFF
--- a/.github/workflows/build-rust-wheels.yml
+++ b/.github/workflows/build-rust-wheels.yml
@@ -174,7 +174,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           password: ${{ secrets.PYPI_API_TOKEN_RUST }}
           skip-existing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -37,7 +37,7 @@ jobs:
         .
 
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Publish distribution 📦 to Test PyPI
       if: github.event_name == 'workflow_dispatch' && inputs.publish
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -3,12 +3,12 @@ sphinx==9.1.0
 sphinx-autobuild==2025.8.25
 
 # if using typehints
-sphinx-autodoc-typehints==3.9.8
+sphinx-autodoc-typehints==3.12.1
 
 mock==5.2.0
 autodoc==0.5.0
 
 tornado==6.5.7
 jinja2==3.1.6
-idna==3.15
+idna==3.18
 starlette==1.3.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -36,7 +36,7 @@ furo==2025.12.19
     # via -r requirements.in
 h11==0.16.0
     # via uvicorn
-idna==3.15
+idna==3.18
     # via
     #   -r requirements.in
     #   anyio
@@ -79,7 +79,7 @@ sphinx==9.1.0
     #   sphinx-basic-ng
 sphinx-autobuild==2025.8.25
     # via -r requirements.in
-sphinx-autodoc-typehints==3.9.8
+sphinx-autodoc-typehints==3.12.1
     # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,10 +2,10 @@
 -r requirements.in
 xmltodict>=0.14.2
 pytest>=8.4.1
-pytest-cov>=7.0.0
+pytest-cov>=7.1.0
 pytest-xdist>=3.8.0
-coverage>=7.10.3
-ruff>=0.12.8
+coverage>=7.15.2
+ruff>=0.15.22
 setuptools>=80.9.0
 pygments>=2.20.0
 # Note: ty is run via uvx, not installed as a dependency

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-dev.in
 #
-coverage==7.13.1
+coverage[toml]==7.15.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -23,19 +23,19 @@ pluggy==1.5.0
     #   pytest
     #   pytest-cov
 pygments==2.20.0
-    # via pytest
+    # via
+    #   -r requirements-dev.in
+    #   pytest
 pytest==9.0.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
     #   pytest-xdist
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements-dev.in
 pytest-xdist==3.8.0
     # via -r requirements-dev.in
-ruff==0.12.8
-    # via -r requirements-dev.in
-setuptools==82.0.1
+ruff==0.15.22
     # via -r requirements-dev.in
 tomli==2.4.1
     # via
@@ -45,5 +45,5 @@ typing-extensions==4.15.0
     # via exceptiongroup
 urllib3==2.7.0
     # via -r requirements.in
-xmltodict==0.14.2
+xmltodict==1.0.4
     # via -r requirements-dev.in


### PR DESCRIPTION
Combines the tested changes from #344 through #354 into one linear branch, as required by the master branch rules.

Includes:
- CodeQL action 4.37.1 alignment across init, autobuild, and analyze
- PyPI publish action 1.14.1
- xmltodict 1.0.4, Ruff 0.15.22, pytest-cov 7.1.0, coverage 7.15.2, and the setuptools lock refresh
- docs idna 3.18 and sphinx-autodoc-typehints 3.12.1

Validation:
- 473 Python tests passed with 100% coverage
- Ruff and ty passed
- 48 Rust tests, cargo fmt, and cargo clippy passed
- lat check passed
- Sphinx dependency install and HTML build completed under the configured Python 3.12 (existing documentation warnings remain)

## Summary by Sourcery

Refresh CI and development dependencies across workflows, Python tooling, and documentation.

Enhancements:
- Update development requirements including xmltodict, Ruff, pytest-cov, coverage, and setuptools lock to current tested versions.

Build:
- Bump CodeQL GitHub Action to v4.37.1 for init, autobuild, and analysis steps.
- Update PyPI publish GitHub Action to v1.14.1 in release workflows.

Documentation:
- Upgrade documentation dependencies idna and sphinx-autodoc-typehints to newer compatible versions.