### PR TITLE
Fix/empty cli input values

### DIFF
--- a/json2xml/cli.py
+++ b/json2xml/cli.py
@@ -109,13 +109,13 @@ class CLIApplication:
     """Thin command adapter around input resolution, conversion, and output."""
 
     def read_input(self, options: CLIConversionOptions) -> JSONValue:
-        if options.url:
+        if options.url is not None:
             try:
                 return readfromurl(options.url)
             except URLReadError as error:
                 exit_with_error(f"Error reading from URL: {error}")
 
-        if options.string:
+        if options.string is not None:
             try:
                 return readfromstring(options.string)
             except StringReadError as error:
@@ -125,9 +125,14 @@ class CLIApplication:
                     f"({error})"
                 )
 
-        if options.input_file:
+        if options.input_file is not None:
             if options.input_file == "-":
                 return read_from_stdin()
+            if not options.input_file:
+                exit_with_error(
+                    "Error: Empty JSON file path. "
+                    "Pass a JSON file, use - for stdin, or provide --string/--url."
+                )
             if not Path(options.input_file).is_file():
                 exit_with_error(
                     f"Error: JSON file not found: {options.input_file}. "

--- a/json2xml/cli.py
+++ b/json2xml/cli.py
@@ -109,6 +109,7 @@ class CLIApplication:
     """Thin command adapter around input resolution, conversion, and output."""
 
     def read_input(self, options: CLIConversionOptions) -> JSONValue:
+        # None means omitted; explicit empty values still require source validation.
         if options.url is not None:
             try:
                 return readfromurl(options.url)

--- a/lat.md/behavior.md
+++ b/lat.md/behavior.md
@@ -10,6 +10,8 @@ The input helpers convert files, strings, URLs, and stdin into Python data struc
 
 [[json2xml/utils.py#readfromurl]] lazily initializes the HTTP client, performs a bounded GET request, and raises `URLReadError` for hostname encoding, network, status, size, decoding, and JSON failures.
 
+[[json2xml/cli.py#CLIApplication#read_input]] selects URL, string, and file sources by argument presence, not truthiness. Explicit empty values therefore reach source-specific validation instead of falling back to a later source or stdin.
+
 ## URL security boundaries
 
 Remote JSON reads default to public, credential-free HTTP(S) targets and bounded decoded responses so callers do not accidentally expose internal services or unlimited memory.

--- a/lat.md/tests.md
+++ b/lat.md/tests.md
@@ -14,6 +14,18 @@ These tests lock down how the CLI chooses among competing input sources so calle
 
 When both URL and string inputs are present, the CLI should read from the URL first so the documented source precedence remains stable.
 
+### Explicit empty string rejects piped stdin
+
+An explicitly empty `--string` value should fail string validation instead of silently selecting piped stdin, preserving the caller's chosen source.
+
+### Explicit empty URL rejects piped stdin
+
+An explicitly empty `--url` value should fail URL validation instead of silently selecting piped stdin, preserving the caller's chosen source.
+
+### Explicit empty file path rejects piped stdin
+
+An explicitly empty positional path should fail with an empty-path error instead of silently selecting piped stdin, preserving the caller's chosen source.
+
 ### Dash argument reads stdin
 
 When the positional input is `-`, the CLI should read stdin instead of trying to open a file literally named `-`.
@@ -61,6 +73,10 @@ Running the CLI without JSON should fail with a message that tells users to pass
 ### Invalid file JSON names the source
 
 Malformed JSON read from an existing file should mention that file path so users can distinguish file parsing failures from missing-file, string, stdin, or conversion failures.
+
+### Empty file path names the empty source
+
+An explicitly empty positional path should report an empty-path error rather than a confusing missing-file message naming nothing.
 
 ### No-input guard stays total if exit helper is bypassed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,45 @@ class TestCLI:
         assert result.returncode == 1
         assert "Invalid JSON in --string input" in result.stderr
 
+    # @lat: [[tests#CLI input resolution#Explicit empty string rejects piped stdin]]
+    def test_empty_string_does_not_fall_back_to_stdin(self) -> None:
+        """Test an explicit empty string remains the selected input source."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-s", ""],
+            input='{"stdin": "unexpected"}',
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "Invalid JSON in --string input" in result.stderr
+        assert result.stdout == ""
+
+    # @lat: [[tests#CLI input resolution#Explicit empty URL rejects piped stdin]]
+    def test_empty_url_does_not_fall_back_to_stdin(self) -> None:
+        """Test an explicit empty URL remains the selected input source."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", "-u", ""],
+            input='{"stdin": "unexpected"}',
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "Error reading from URL" in result.stderr
+        assert result.stdout == ""
+
+    # @lat: [[tests#CLI input resolution#Explicit empty file path rejects piped stdin]]
+    def test_empty_file_path_does_not_fall_back_to_stdin(self) -> None:
+        """Test an explicit empty file path remains the selected input source."""
+        result = subprocess.run(
+            [sys.executable, "-m", "json2xml.cli", ""],
+            input='{"stdin": "unexpected"}',
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 1
+        assert "Empty JSON file path" in result.stderr
+        assert result.stdout == ""
+
     def test_no_input_error(self) -> None:
         """Test error when no input is provided."""
         # Force isatty to return True by using a pty-like environment
@@ -606,6 +645,21 @@ class TestCLIUnitTests:
 
         captured = capsys.readouterr()
         assert "Error reading from URL" in captured.err
+
+    # @lat: [[tests#CLI failure messages#Empty file path names the empty source]]
+    def test_read_input_empty_file_path(self, capsys: CaptureFixture[str]) -> None:
+        """Test read_input rejects an explicitly empty file path."""
+        args = MagicMock()
+        args.url = None
+        args.string = None
+        args.input_file = ""
+
+        with pytest.raises(SystemExit) as exc_info:
+            read_input(args)
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Empty JSON file path" in captured.err
 
     def test_read_input_json_file_error(self, capsys: CaptureFixture[str]) -> None:
         """Test read_input handles JSON file read errors."""


### PR DESCRIPTION
## Summary by Sourcery

Validate explicitly provided CLI input sources without treating empty values as omitted.

Bug Fixes:
- Preserve explicitly provided empty URL, string, and file inputs for source-specific validation instead of falling back to stdin or another source.
- Report a clear error when an explicitly empty file path is supplied.

Documentation:
- Document input-source selection by argument presence and the expected handling of explicit empty values.

Tests:
- Add CLI coverage for empty URL, string, and file inputs, including piped-stdin scenarios and empty-path error messaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicitly empty URL, string, and file inputs are now validated correctly instead of being mistaken for missing options.
  - Empty file paths produce a clear, dedicated error message.
  - Invalid empty inputs no longer unexpectedly fall back to piped standard input.

- **Documentation**
  - Updated input-handling documentation to clarify that source selection is based on whether an option was provided, including empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->