### PR TITLE
Combine pending dependabot updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,6 @@ jobs:
         uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -10,7 +10,7 @@ autodoc==0.5.0
 
 tornado==6.5.8
 jinja2==3.1.6
-idna==3.18
+idna==3.19
 starlette==1.6.0
 
 requests>=2.34.2

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -3,7 +3,7 @@ sphinx==9.1.0
 sphinx-autobuild==2025.8.25
 
 # if using typehints
-sphinx-autodoc-typehints==3.13.2
+sphinx-autodoc-typehints==3.13.4
 
 mock==5.2.0
 autodoc==0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -113,7 +113,7 @@ waitress==3.0.2
     # via webtest
 watchfiles==1.0.4
     # via sphinx-autobuild
-webob==1.8.10
+webob==1.8.11
     # via webtest
 websockets==15.0
     # via sphinx-autobuild

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -81,7 +81,7 @@ sphinx==9.1.0
     #   sphinx-basic-ng
 sphinx-autobuild==2025.8.25
     # via -r requirements.in
-sphinx-autodoc-typehints==3.13.2
+sphinx-autodoc-typehints==3.13.4
     # via -r requirements.in
 sphinx-basic-ng==1.0.0b2
     # via furo

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -36,7 +36,7 @@ furo==2025.12.19
     # via -r requirements.in
 h11==0.16.0
     # via uvicorn
-idna==3.18
+idna==3.19
     # via
     #   -r requirements.in
     #   anyio


### PR DESCRIPTION
Merges the six open dependabot PRs into one branch.

Closes #421, closes #422, closes #423: codeql-action init/autobuild/analyze 4.37.7 -> 4.37.9
Closes #420: sphinx-autodoc-typehints 3.13.2 -> 3.13.4 (docs)
Closes #406: webob 1.8.10 -> 1.8.11 (docs)
Closes #402: idna 3.18 -> 3.19 (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017R5meHsqSLN5x52iP3zbGc

## Summary by Sourcery

Consolidate pending dependency updates for CodeQL analysis and documentation tooling.

Enhancements:
- Update documentation dependencies, including idna, sphinx-autodoc-typehints, and webob, to their latest specified patch releases.

CI:
- Update CodeQL workflow actions from v4.37.7 to v4.37.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code analysis workflow actions to newer pinned versions.
  - Refreshed documentation tooling and supporting package versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->